### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-05-07
+
+### Added
+
+- `Dockerfile` — layered on `ghcr.io/jwilleke/ngdpbase`; copies addon and root deps into `/opt/geohazardwatch/`. Imported data stays on a runtime volume, not baked in.
+- `.dockerignore` — keeps the build context small (excludes `node_modules`, `private/`, `addons/ve-geology/data/`, etc.).
+- `.github/workflows/publish-image.yml` — tag-triggered build, multi-tag semver push to `ghcr.io/jwilleke/geohazardwatch`, smoke test, Trivy scan.
+- `renovate.json` — minor + patch auto-merge for the base image and npm deps; majors require manual review; weekly schedule.
+
+### Changed
+
+- Repo renamed from `jwilleke/ve-geology` to `jwilleke/geohazardwatch`. Old URLs redirect; canonical name now matches the public domain.
+
+### Fixed
+
 ## [1.0.1] - 2026-03-31
 
 ### Added
@@ -55,5 +70,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Addon context page at `/wiki/ve-geology-about`
 - ESLint + markdownlint + Prettier + Husky pre-commit hook
 
-[1.0.1]: https://github.com/jwilleke/ve-geology/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/jwilleke/ve-geology/releases/tag/v1.0.0
+[1.0.1]: https://github.com/jwilleke/geohazardwatch/compare/v1.0.0...v1.0.1
+[1.1.0]: https://github.com/jwilleke/geohazardwatch/compare/v1.0.1...v1.1.0
+[1.0.0]: https://github.com/jwilleke/geohazardwatch/releases/tag/v1.0.0

--- a/addons/ve-geology/index.js
+++ b/addons/ve-geology/index.js
@@ -52,7 +52,7 @@ const _intervals = [];
 
 module.exports = {
   name: 've-geology',
-  version: '1.0.1',
+  version: '1.1.0',
   description: 'Volcano & geology data platform — GVP structured records, search, infoboxes, maps',
   author: 'jwilleke',
   dependencies: [],

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -39,6 +39,22 @@ This document tracks ongoing work and session history for the ve-geology project
 
 ## Session Logs
 
+### 2026-05-07-02
+
+- **Agent:** Claude Opus 4.7
+- **Subject:** Release v1.1.0 — first dockerized release
+- **Work Done:**
+  - Merged `#19` (Dockerfile, image-publish workflow, Renovate) onto `main`.
+  - `npm run version:bump -- minor` → 1.0.1 → 1.1.0 (updated `package.json`, `addons/ve-geology/index.js`, `CHANGELOG.md`).
+  - Filled in CHANGELOG `[1.1.0]` section with the new artifacts and the repo rename note.
+  - Replaced stale `jwilleke/ve-geology` URLs in `src/utils/version.ts` and CHANGELOG link footers with the new `jwilleke/geohazardwatch` canonical URL.
+  - Tag `v1.1.0` will trigger `publish-image.yml` to publish `ghcr.io/jwilleke/geohazardwatch:{1.1.0, 1.1, 1, latest}`.
+- **Files Modified:**
+  - `package.json`, `addons/ve-geology/index.js`
+  - `CHANGELOG.md`
+  - `src/utils/version.ts`
+  - `docs/project_log.md` (this file)
+
 ### 2026-05-07-01
 
 - **Agent:** Claude Opus 4.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ve-geology",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Volcano & geology add-on for ngdpbase",
   "private": true,
   "scripts": {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -94,7 +94,7 @@ function updateChangelog(next: string, prev: string): void {
     '',
   ].join('\n');
 
-  const linkLine = `[${next}]: https://github.com/jwilleke/ve-geology/compare/v${prev}...v${next}`;
+  const linkLine = `[${next}]: https://github.com/jwilleke/geohazardwatch/compare/v${prev}...v${next}`;
 
   // Insert new section before the first ## [x.y.z] heading
   const updated = content


### PR DESCRIPTION
## Summary

First dockerized release — bundles up the work merged in #19.

- `package.json` 1.0.1 → 1.1.0
- `addons/ve-geology/index.js` version string bumped
- `CHANGELOG.md`: filled in `[1.1.0]` section
- `src/utils/version.ts` + `CHANGELOG.md` link footers: replaced stale `jwilleke/ve-geology` URLs with the renamed `jwilleke/geohazardwatch` canonical
- `docs/project_log.md`: session entry

## Why minor (not patch)

`v1.1.0` adds the ability to ship as a container with auto-update infrastructure — that's a notable new capability, not a bug fix. Per semver, minor.

## What happens after merge

When this lands on `main`, the merged commit will be tagged `v1.1.0` (separately, since squash-merge creates a new commit hash). Pushing that tag fires `publish-image.yml`, which builds and publishes:

- `ghcr.io/jwilleke/geohazardwatch:1.1.0`
- `ghcr.io/jwilleke/geohazardwatch:1.1`
- `ghcr.io/jwilleke/geohazardwatch:1`
- `ghcr.io/jwilleke/geohazardwatch:latest`

That image is what `mj-infra-flux#48` will pull.

## Test plan

- [ ] Squash-merge this PR.
- [ ] Tag the merged commit as `v1.1.0` and push the tag.
- [ ] Confirm `Publish container image` workflow runs green and the image appears at `ghcr.io/jwilleke/geohazardwatch`.
- [ ] Pull `ghcr.io/jwilleke/geohazardwatch:1.1.0` locally and run with `HEADLESS_INSTALL=true`; root URL responds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)