### PR TITLE
fix: pin Dockerfile base image to existing ngdpbase tag (v1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-07
+
+### Fixed
+
+- `Dockerfile` — base image reference was `ghcr.io/jwilleke/ngdpbase:v3.10.0`,
+  which doesn't exist. Published `ngdpbase` image tags don't carry the `v`
+  prefix (the `docker/metadata-action` strips it), and the most recent
+  published `ngdpbase` release is `3.9.0`, not `3.10.0`. Pinned to `3.9.0` —
+  Renovate will PR an upgrade once `ngdpbase` publishes `3.10.0`. Without this
+  fix, the v1.1.0 release workflow failed at `FROM` resolution.
+
 ## [1.1.0] - 2026-05-07
 
 ### Added
@@ -72,4 +83,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.0.1]: https://github.com/jwilleke/geohazardwatch/compare/v1.0.0...v1.0.1
 [1.1.0]: https://github.com/jwilleke/geohazardwatch/compare/v1.0.1...v1.1.0
+[1.1.1]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.0...v1.1.1
 [1.0.0]: https://github.com/jwilleke/geohazardwatch/releases/tag/v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-ARG NGDPBASE_VERSION=v3.10.0
+ARG NGDPBASE_VERSION=3.9.0
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"

--- a/addons/ve-geology/index.js
+++ b/addons/ve-geology/index.js
@@ -52,7 +52,7 @@ const _intervals = [];
 
 module.exports = {
   name: 've-geology',
-  version: '1.1.0',
+  version: '1.1.1',
   description: 'Volcano & geology data platform — GVP structured records, search, infoboxes, maps',
   author: 'jwilleke',
   dependencies: [],

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -39,6 +39,21 @@ This document tracks ongoing work and session history for the ve-geology project
 
 ## Session Logs
 
+### 2026-05-07-03
+
+- **Agent:** Claude Opus 4.7
+- **Subject:** v1.1.1 — fix broken Dockerfile base image reference
+- **Work Done:**
+  - v1.1.0 publish-image workflow failed at `FROM ghcr.io/jwilleke/ngdpbase:v3.10.0` — `not found`.
+  - Two issues: ngdpbase's `docker/metadata-action` strips the `v` from published image tags (so the published tag is `3.10.0`, not `v3.10.0`), AND ngdpbase's latest *published* release is `v3.9.0` — `v3.10.0` is in-progress in `package.json` but not yet tagged on the ngdpbase repo.
+  - Pinned base image to `3.9.0`. Renovate will auto-PR an upgrade once `ngdpbase` publishes `3.10.0`.
+  - Bumped to v1.1.1 (patch — broken-on-arrival fix).
+- **Files Modified:**
+  - `Dockerfile`
+  - `package.json`, `addons/ve-geology/index.js`
+  - `CHANGELOG.md`
+  - `docs/project_log.md` (this file)
+
 ### 2026-05-07-02
 
 - **Agent:** Claude Opus 4.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ve-geology",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Volcano & geology add-on for ngdpbase",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

v1.1.0 was broken on arrival — the publish-image workflow failed at `FROM ghcr.io/jwilleke/ngdpbase:v3.10.0`: not found.

Two root causes:
1. The upstream `ngdpbase` image is published with `docker/metadata-action`'s `type=semver,pattern={{version}}`, which strips the `v` prefix. The actual published tag would be `3.10.0`, not `v3.10.0`.
2. **More importantly:** `ngdpbase`'s latest *released* tag on GitHub is `v3.9.0`. The `3.10.0` in `package.json` is an in-progress bump that hasn't been tagged on the `ngdpbase` repo yet.

## Fix

Pinned to `ghcr.io/jwilleke/ngdpbase:3.9.0`. Renovate will auto-PR an upgrade once `ngdpbase` publishes `3.10.0`.

Bumped to `v1.1.1` (patch — broken-on-arrival fix).

## Test plan

- [ ] Squash-merge.
- [ ] Tag `v1.1.1` on the merged commit and push.
- [ ] Confirm `Publish container image` workflow runs green.
- [ ] Image appears at `ghcr.io/jwilleke/geohazardwatch:1.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)