### PR TITLE
fix: add --ignore-scripts to npm ci in Dockerfile (v1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-05-07
+
+### Fixed
+
+- `Dockerfile` — `npm ci --omit=dev` ran the `prepare` lifecycle script,
+  which calls `husky install`. Husky is a devDependency that's not installed
+  under `--omit=dev`, so the script exited 127. Added `--ignore-scripts` to
+  skip lifecycle scripts during the container build — git hooks aren't
+  meaningful inside a runtime image. Without this fix, the v1.1.1 publish
+  workflow failed at `RUN npm ci`.
+
 ## [1.1.1] - 2026-05-07
 
 ### Fixed
@@ -84,4 +95,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.1]: https://github.com/jwilleke/geohazardwatch/compare/v1.0.0...v1.0.1
 [1.1.0]: https://github.com/jwilleke/geohazardwatch/compare/v1.0.1...v1.1.0
 [1.1.1]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.0...v1.1.1
+[1.1.2]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.1...v1.1.2
 [1.0.0]: https://github.com/jwilleke/geohazardwatch/releases/tag/v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@ WORKDIR /opt/geohazardwatch
 
 COPY package.json package-lock.json ./
 
-RUN npm ci --omit=dev
+# --ignore-scripts skips the `prepare` lifecycle (husky install). Husky is a
+# devDependency that isn't present under --omit=dev, and the resulting
+# `husky: not found` makes npm ci exit 127. We don't need git hooks in a
+# runtime container.
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY addons ./addons
 COPY src ./src

--- a/addons/ve-geology/index.js
+++ b/addons/ve-geology/index.js
@@ -52,7 +52,7 @@ const _intervals = [];
 
 module.exports = {
   name: 've-geology',
-  version: '1.1.1',
+  version: '1.1.2',
   description: 'Volcano & geology data platform — GVP structured records, search, infoboxes, maps',
   author: 'jwilleke',
   dependencies: [],

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -39,6 +39,21 @@ This document tracks ongoing work and session history for the ve-geology project
 
 ## Session Logs
 
+### 2026-05-07-04
+
+- **Agent:** Claude Opus 4.7
+- **Subject:** v1.1.2 — fix `npm ci --omit=dev` failure on husky prepare script
+- **Work Done:**
+  - v1.1.1 publish workflow failed at `RUN npm ci --omit=dev` with `sh: husky: not found, npm error code 127`.
+  - Root cause: package.json `prepare` script calls `husky install`. With `--omit=dev`, husky (a devDependency) isn't installed, so the script fails. The container build doesn't need git hooks anyway.
+  - Added `--ignore-scripts` to the npm ci invocation to skip lifecycle scripts during the runtime build.
+  - Bumped to v1.1.2.
+- **Files Modified:**
+  - `Dockerfile`
+  - `package.json`, `addons/ve-geology/index.js`
+  - `CHANGELOG.md`
+  - `docs/project_log.md` (this file)
+
 ### 2026-05-07-03
 
 - **Agent:** Claude Opus 4.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ve-geology",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Volcano & geology add-on for ngdpbase",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

v1.1.1's publish-image workflow failed at `RUN npm ci --omit=dev`:

```
sh: husky: not found
npm error code 127
npm error path /opt/geohazardwatch
npm error command failed
npm error command sh -c husky install
```

## Root cause

`package.json`'s `prepare` lifecycle script runs `husky install`. Husky is a devDependency, so under `--omit=dev` it isn't present — but `prepare` still tries to run, exiting 127.

## Fix

Added `--ignore-scripts` to the `npm ci` invocation. Lifecycle scripts (notably `prepare` → `husky install`) are skipped during the container build. This is correct for a runtime image — git hooks aren't meaningful in a container, and `prepare` is the only lifecycle script in this repo.

Bumped to v1.1.2 (patch).

## Test plan

- [ ] Squash-merge.
- [ ] Tag `v1.1.2` on the merged commit and push.
- [ ] Confirm `Publish container image` runs green.
- [ ] Image at `ghcr.io/jwilleke/geohazardwatch:1.1.2` pulls and starts with `HEADLESS_INSTALL=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)