### PR TITLE
fix: replace placeholder seed-page UUIDs with real v4 UUIDs (v1.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-05-07
+
+### Fixed
+
+- Replaced placeholder `uuid` frontmatter on all 8 seed pages
+  (`ve-geology-about`, `ve-geology-demo`, `ve-geology-earthquakes`,
+  `ve-geology-hans`, `ve-geology-home`, `ve-geology-japan`,
+  `ve-geology-plugins`, `ve-geology-volcanoes`) with real UUID v4 values.
+  The placeholders contained non-hex characters (`v`, `g`, `l`, `o`, `y`)
+  and were rejected by `AddonsManager`'s validator (`/^[0-9a-f]{8}-…$/`),
+  so none of the pages were being seeded into the wiki on startup. See
+  the upstream [addon development guide](https://github.com/jwilleke/ngdpbase/blob/master/docs/platform/addon-development-guide.md#uuid-requirements)
+  for the rules.
+
 ## [1.1.2] - 2026-05-07
 
 ### Fixed
@@ -96,4 +110,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/jwilleke/geohazardwatch/compare/v1.0.1...v1.1.0
 [1.1.1]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.0...v1.1.1
 [1.1.2]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.1...v1.1.2
+[1.1.3]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.2...v1.1.3
 [1.0.0]: https://github.com/jwilleke/geohazardwatch/releases/tag/v1.0.0

--- a/addons/ve-geology/index.js
+++ b/addons/ve-geology/index.js
@@ -52,7 +52,7 @@ const _intervals = [];
 
 module.exports = {
   name: 've-geology',
-  version: '1.1.2',
+  version: '1.1.3',
   description: 'Volcano & geology data platform — GVP structured records, search, infoboxes, maps',
   author: 'jwilleke',
   dependencies: [],

--- a/addons/ve-geology/pages/ve-geology-about.md
+++ b/addons/ve-geology/pages/ve-geology-about.md
@@ -1,6 +1,6 @@
 ---
 title: About ve-geology
-uuid: a1b2c3d4-0007-4000-8000-ve0geology007
+uuid: 98f2df76-5d86-472a-9862-9a01267cf4a7
 slug: ve-geology-about
 description: What ve-geology is, where the data comes from, and how to interpret data freshness
 tags: [geology, about, data-sources, volcanoes, earthquakes]

--- a/addons/ve-geology/pages/ve-geology-demo.md
+++ b/addons/ve-geology/pages/ve-geology-demo.md
@@ -1,6 +1,6 @@
 ---
 title: Geology Demo
-uuid: a1b2c3d4-0003-4000-8000-ve0geology003
+uuid: 37a05b59-a793-4204-b389-f5e89fb80537
 slug: geology-demo
 author: system
 user-keywords:

--- a/addons/ve-geology/pages/ve-geology-earthquakes.md
+++ b/addons/ve-geology/pages/ve-geology-earthquakes.md
@@ -1,6 +1,6 @@
 ---
 title: Earthquakes
-uuid: a1b2c3d4-0002-4000-8000-ve0geology002
+uuid: ac0ce090-ddae-44cc-b5e8-0d9c5922e5dc
 slug: earthquakes
 author: system
 user-keywords:

--- a/addons/ve-geology/pages/ve-geology-hans.md
+++ b/addons/ve-geology/pages/ve-geology-hans.md
@@ -1,6 +1,6 @@
 ---
 title: US Volcano Alerts (USGS HANS)
-uuid: a1b2c3d4-0005-4000-8000-ve0geology005
+uuid: ea663c20-6809-4443-91ba-6cefbf48b2e1
 slug: volcano-alerts
 description: Real-time US volcano alert levels from the USGS Hazard Alert Notification System
 tags: [geology, volcanoes, alerts, usgs]

--- a/addons/ve-geology/pages/ve-geology-home.md
+++ b/addons/ve-geology/pages/ve-geology-home.md
@@ -1,6 +1,6 @@
 ---
 title: Volcanoes and Earthquakes
-uuid: a1b2c3d4-0006-4000-8000-ve0geology006
+uuid: 4bf246b9-ebcc-4774-8175-427c275d407c
 slug: volcanoes-and-earthquakes
 system-category: addon
 description: Home page for the ve-geology volcano and earthquake data platform

--- a/addons/ve-geology/pages/ve-geology-japan.md
+++ b/addons/ve-geology/pages/ve-geology-japan.md
@@ -1,6 +1,6 @@
 ---
 title: Japan Volcanoes
-uuid: a1b2c3d4-0004-4000-8000-ve0geology004
+uuid: d72befb6-5596-4e7e-b0ca-5c95d7ff32c1
 slug: japan-volcanoes
 author: system
 user-keywords:

--- a/addons/ve-geology/pages/ve-geology-plugins.md
+++ b/addons/ve-geology/pages/ve-geology-plugins.md
@@ -1,6 +1,6 @@
 ---
 title: Plugin Guide
-uuid: a1b2c3d4-0008-4000-8000-ve0geology008
+uuid: 93595dc0-1ba1-422a-9fd4-c2f6bf056b27
 slug: ve-geology-plugins
 description: End-user guide to all ve-geology wiki plugins — what they render, how to use them, and common combinations
 tags: [geology, plugins, guide, volcanoes, earthquakes]

--- a/addons/ve-geology/pages/ve-geology-volcanoes.md
+++ b/addons/ve-geology/pages/ve-geology-volcanoes.md
@@ -1,6 +1,6 @@
 ---
 title: Volcanoes
-uuid: a1b2c3d4-0001-4000-8000-ve0geology001
+uuid: 3b3828dd-590f-46fe-9030-d3306ed2ac98
 slug: volcanoes
 author: system
 user-keywords:

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -39,6 +39,29 @@ This document tracks ongoing work and session history for the ve-geology project
 
 ## Session Logs
 
+### 2026-05-07-05
+
+- **Agent:** Claude Opus 4.7
+- **Subject:** v1.1.3 — replace placeholder UUIDs with real v4 UUIDs in seed pages
+- **Work Done:**
+  - Live cluster boot logs (after the `addons-path` array fix in `mj-infra-flux#49`) showed all 8 seed pages skipped: `[AddonsManager] Skipping ve-geology/pages/ve-geology-*.md — missing or invalid uuid in frontmatter`.
+  - Root cause: placeholder UUIDs of the form `a1b2c3d4-000N-4000-8000-ve0geology00N` contain non-hex characters (`v`, `g`, `l`, `o`, `y`) and fail ngdpbase's `AddonsManager` validator regex `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i`.
+  - Confirmed against ngdpbase's `docs/platform/addon-development-guide.md` (UUID requirements section) which states the rules and recommends `node -e "console.log(require('crypto').randomUUID())"` for generation.
+  - Generated 8 fresh v4 UUIDs and replaced each page's frontmatter `uuid` field. Existing valid UUIDs on `left-menu-content.md` and `footer-content.md` were left as-is.
+  - Bumped to v1.1.3 (patch — bug in seeded content).
+- **Files Modified:**
+  - `addons/ve-geology/pages/ve-geology-about.md`
+  - `addons/ve-geology/pages/ve-geology-demo.md`
+  - `addons/ve-geology/pages/ve-geology-earthquakes.md`
+  - `addons/ve-geology/pages/ve-geology-hans.md`
+  - `addons/ve-geology/pages/ve-geology-home.md`
+  - `addons/ve-geology/pages/ve-geology-japan.md`
+  - `addons/ve-geology/pages/ve-geology-plugins.md`
+  - `addons/ve-geology/pages/ve-geology-volcanoes.md`
+  - `package.json`, `addons/ve-geology/index.js`
+  - `CHANGELOG.md`
+  - `docs/project_log.md` (this file)
+
 ### 2026-05-07-04
 
 - **Agent:** Claude Opus 4.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ve-geology",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Volcano & geology add-on for ngdpbase",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

After deploying v1.1.2 to the cluster (with the `mj-infra-flux` `addons-path` array fix), boot logs showed:

```
[AddonsManager] Skipping ve-geology/pages/ve-geology-about.md — missing or invalid uuid in frontmatter
[AddonsManager] Skipping ve-geology/pages/ve-geology-demo.md — missing or invalid uuid in frontmatter
[AddonsManager] Skipping ve-geology/pages/ve-geology-earthquakes.md — missing or invalid uuid in frontmatter
[AddonsManager] Skipping ve-geology/pages/ve-geology-hans.md — missing or invalid uuid in frontmatter
[AddonsManager] Skipping ve-geology/pages/ve-geology-home.md — missing or invalid uuid in frontmatter
[AddonsManager] Skipping ve-geology/pages/ve-geology-japan.md — missing or invalid uuid in frontmatter
[AddonsManager] Skipping ve-geology/pages/ve-geology-plugins.md — missing or invalid uuid in frontmatter
[AddonsManager] Skipping ve-geology/pages/ve-geology-volcanoes.md — missing or invalid uuid in frontmatter
✅ Add-on loaded: ve-geology v1.1.2
```

The addon loaded but seeded zero pages — the wiki has no ve-geology content.

## Root cause

Each page's frontmatter had a placeholder `uuid` of the form `a1b2c3d4-000N-4000-8000-ve0geology00N`. The placeholders contain non-hex characters (`v`, `g`, `l`, `o`, `y`).

ngdpbase `AddonsManager` validates against:

```
/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
```

…and skips any page that doesn't match. The placeholder format passes the structural shape but fails the hex requirement.

## Fix

Generated fresh UUID v4 values (`node -e "console.log(require('crypto').randomUUID())"`) and replaced each page's `uuid` field. `left-menu-content.md` and `footer-content.md` already had valid UUIDs and were left as-is.

Cross-checked against the upstream [addon development guide](https://github.com/jwilleke/ngdpbase/blob/master/docs/platform/addon-development-guide.md) UUID requirements section, which documents the rules and recommends `crypto.randomUUID()` for generation.

Bumped to v1.1.3 (patch — content bug, no API change).

## Test plan

- [ ] Squash-merge.
- [ ] Tag `v1.1.3` and push.
- [ ] Confirm `Publish container image` runs green and `ghcr.io/jwilleke/geohazardwatch:1.1.3` is published.
- [ ] In `mj-infra-flux`, bump the image tag to `1.1.3` (or wait for image automation, once bootstrapped).
- [ ] After rollout, confirm `kubectl logs` shows `Add-on loaded: ve-geology v1.1.3` followed by **no** "Skipping … missing or invalid uuid" warnings, and that the seeded pages appear in `kubectl exec ... ls /app/data/pages/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)