### PR TITLE
chore: bump ngdpbase base image to 3.10.1 (v1.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2026-05-07
+
+### Changed
+
+- Bumped `Dockerfile` base image from `ghcr.io/jwilleke/ngdpbase:3.9.0` to
+  `3.10.1`. 3.10 introduced the OrganizationRole-based role assignment that
+  the headless install needs in order for the seeded `admin` user to actually
+  carry the `admin` role at login. Without it (3.9.x), `admin` resolved to the
+  implicit `All` role and the cluster deployment showed no Edit button or
+  admin dashboard.
+
 ## [1.1.3] - 2026-05-07
 
 ### Fixed
@@ -111,4 +122,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.1]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.0...v1.1.1
 [1.1.2]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.1...v1.1.2
 [1.1.3]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.2...v1.1.3
+[1.1.4]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.3...v1.1.4
 [1.0.0]: https://github.com/jwilleke/geohazardwatch/releases/tag/v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-ARG NGDPBASE_VERSION=3.9.0
+ARG NGDPBASE_VERSION=3.10.1
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"

--- a/addons/ve-geology/index.js
+++ b/addons/ve-geology/index.js
@@ -52,7 +52,7 @@ const _intervals = [];
 
 module.exports = {
   name: 've-geology',
-  version: '1.1.3',
+  version: '1.1.4',
   description: 'Volcano & geology data platform — GVP structured records, search, infoboxes, maps',
   author: 'jwilleke',
   dependencies: [],

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -39,6 +39,24 @@ This document tracks ongoing work and session history for the ve-geology project
 
 ## Session Logs
 
+### 2026-05-07-06
+
+- **Agent:** Claude Opus 4.7
+- **Subject:** v1.1.4 — bump ngdpbase base image to 3.10.1
+- **Symptom on cluster:** Logged-in `admin` user had no Edit button and no admin dashboard. The page showed `GeoHazardWatch v3.9.0`.
+- **Root cause:** Cluster image was layered on `ghcr.io/jwilleke/ngdpbase:3.9.0`.
+  ngdpbase 3.10 introduced OrganizationRole records in `data/roles/` (per
+  `User.ts:78` deprecation note for the legacy `roles[]` field). 3.9's headless
+  install never created those records, so `UserManager.resolveUserRoles('admin')`
+  returned an empty role set and the policy evaluator treated the admin user as
+  `Anonymous|All`.
+- **Fix:** Bumped `Dockerfile` `ARG NGDPBASE_VERSION=3.9.0` → `3.10.1`. v3.10.0 was cut earlier today and v3.10.1 (just published) is the first release with the image landing in `ghcr.io/jwilleke/ngdpbase`.
+- **Files Modified:**
+  - `Dockerfile`
+  - `package.json`, `addons/ve-geology/index.js`
+  - `CHANGELOG.md`
+  - `docs/project_log.md` (this file)
+
 ### 2026-05-07-05
 
 - **Agent:** Claude Opus 4.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ve-geology",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Volcano & geology add-on for ngdpbase",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Bump `Dockerfile` `ARG NGDPBASE_VERSION` from `3.9.0` to `3.10.1` so the cluster deployment picks up ngdpbase's new role-assignment behaviour. Releases as `v1.1.4`.

## Why now

Cluster deployment was showing `GeoHazardWatch v3.9.0` with **no Edit button and no admin dashboard** for the seeded `admin` user, even in a fresh incognito session.

Diagnosis:
- `/app/data/users/users.json` admin record had no `roles` field.
- `/app/data/roles/` and `/app/data/organizations/` were empty.
- ACL log showed `user=Anonymous roles=Anonymous|All` despite a successful login.

Looking at upstream `ngdpbase` `src/types/User.ts:78`:

> @deprecated since #617 iteration 3b. Role membership is now stored
> canonically as OrganizationRole records owned by RoleManager; resolve
> a user's roles via `UserManager.resolveUserRoles(username)`.

3.10 moved role storage to per-user `OrganizationRole` records and updated the headless-install path to create them. 3.9's headless install never created those records, so `resolveUserRoles('admin')` returned an empty set and the policy evaluator treated admin as Anonymous.

`ngdpbase v3.10.1` was tagged and published to `ghcr.io/jwilleke/ngdpbase:3.10.1` minutes ago. Bumping.

## Test plan

- [ ] Squash-merge.
- [ ] Tag `v1.1.4` and push.
- [ ] Confirm `Publish container image` runs green and `ghcr.io/jwilleke/geohazardwatch:1.1.4` appears.
- [ ] Bump `mj-infra-flux` `image:` tag from `1.1.3` → `1.1.4` (separate PR).
- [ ] After rollout: admin login on `https://geohazardwatch.nerdsbythehour.com/` should show the Edit button and admin dashboard, and the page header should read `v3.10.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)