### PR TITLE
chore: bump ngdpbase to 3.10.3 + seed request-access page (v1.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2026-05-08
+
+### Added
+
+- New seed page `addons/ve-geology/pages/ve-geology-request-access.md`
+  (slug `request-access`). Destination for the **Request access** button
+  shown when ngdpbase's `ngdpbase.application.registration` flag is `false`.
+  Operator edits the page in the wiki UI to customize contact instructions
+  or drop in a `[{Form …}]` plugin invocation.
+
+### Changed
+
+- Bumped `Dockerfile` base image from `ghcr.io/jwilleke/ngdpbase:3.10.2` to
+  `3.10.3`. ngdpbase 3.10.3 introduces the `ngdpbase.application.registration`
+  config flag (default `true`); operators set it to `false` to lock down
+  self-registration. See ngdpbase PR #654.
+
 ## [1.1.5] - 2026-05-07
 
 ### Changed
@@ -134,4 +151,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.3]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.2...v1.1.3
 [1.1.4]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.3...v1.1.4
 [1.1.5]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.4...v1.1.5
+[1.1.6]: https://github.com/jwilleke/geohazardwatch/compare/v1.1.5...v1.1.6
 [1.0.0]: https://github.com/jwilleke/geohazardwatch/releases/tag/v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-ARG NGDPBASE_VERSION=3.10.2
+ARG NGDPBASE_VERSION=3.10.3
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"

--- a/addons/ve-geology/index.js
+++ b/addons/ve-geology/index.js
@@ -52,7 +52,7 @@ const _intervals = [];
 
 module.exports = {
   name: 've-geology',
-  version: '1.1.5',
+  version: '1.1.6',
   description: 'Volcano & geology data platform — GVP structured records, search, infoboxes, maps',
   author: 'jwilleke',
   dependencies: [],

--- a/addons/ve-geology/pages/ve-geology-request-access.md
+++ b/addons/ve-geology/pages/ve-geology-request-access.md
@@ -1,0 +1,22 @@
+---
+title: Request Access
+uuid: 2731a6b1-1ef6-465b-80b3-2f8ed148476b
+slug: request-access
+system-category: addon
+addon: ve-geology
+author: ve-geology
+description: How to request an account on geohazardwatch.com when self-registration is closed
+---
+
+## Account registration is currently closed
+
+If you'd like an account on **geohazardwatch.com**, please email
+[admin@geohazardwatch.com](mailto:admin@geohazardwatch.com) with a sentence or
+two about who you are and what you'd like to contribute. We typically respond
+within a few days.
+
+This page is the destination for the **Request access** button shown when
+`ngdpbase.application.registration` is set to `false`. Edit it in the wiki UI
+to add or change contact details, link a Google Form, paste a Discord invite,
+or drop in a `[{Form ...}]` plugin invocation when a structured request form
+is ready.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ve-geology",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Volcano & geology add-on for ngdpbase",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Picks up jwilleke/ngdpbase#654 (ngdpbase.application.registration flag) and ships the request-access wiki seed page. Releases as v1.1.6.