### PR TITLE
chore: enable Renovate auto-bump for ngdpbase ARG; bump 3.10.3 → 3.11.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-ARG NGDPBASE_VERSION=3.10.3
+# renovate: datasource=docker depName=ghcr.io/jwilleke/ngdpbase
+ARG NGDPBASE_VERSION=3.11.3
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"


### PR DESCRIPTION
## Summary

- Add `# renovate: datasource=docker depName=ghcr.io/jwilleke/ngdpbase` annotation above the `ARG NGDPBASE_VERSION` line so Renovate's dockerfile manager actually detects the dependency.
- Bump the `ARG NGDPBASE_VERSION` default from `3.10.3` → `3.11.3` in the same commit. Last hand-bump on this ARG, expected.

## Why

`renovate.json` already has the right rules for `ghcr.io/jwilleke/ngdpbase` — minor/patch auto-merge, major requires review, security alerts auto-merge. But Renovate's dockerfile manager only spots `FROM image:tag` literals by default. When the version lives in an `ARG` referenced by `FROM`, you need a `# renovate:` annotation comment for Renovate to find it.

Without that annotation, every recent ngdpbase bump (3.10.1 → 3.10.2 → 3.10.3, PRs #25, #27, #28) shipped via hand-titled PR. The annotation closes that gap — once merged, Renovate will start opening PRs automatically the next time ngdpbase tags a release.

## Why bump 3.10.3 → 3.11.3 in the same commit

The 3.11.x line carries security work that should reach this image:

- **CVE-2026-6321** (high) — `fast-uri` path traversal via percent-encoded dot segments
- **CVE-2026-6322** (high) — `fast-uri` host confusion via percent-encoded authority delimiters
- **CVE-2025-5891** (low) — `pm2` ReDoS in `Config.js`
- Plus three pm2-internal command-injection fixes (proxy-agent, basic-ftp, follow-redirects updates)

Bumping by hand here closes the immediate exposure window; the annotation prevents the next exposure window.

## Decision context

This is the implementation of the recommendation in [jwilleke/ngdpbase#668](https://github.com/jwilleke/ngdpbase/issues/668). The platform side (image publish on every tag) is already deterministic via `.github/workflows/docker-build.yml` in `jwilleke/ngdpbase`. The remaining gap was on the consumer side — this PR closes it.

## Test plan

- [ ] PR check workflows pass (lint, etc.)
- [ ] After merge, force-trigger Renovate (or wait for the Monday 6am schedule) and confirm it now sees `ghcr.io/jwilleke/ngdpbase` as a dependency
- [ ] Optional: rebuild the image locally and confirm `docker run` of the new image still boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)