### PR TITLE
fix(auto-tag): rebase on origin/main and retry when push is non-fast-forward

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -53,4 +53,22 @@ jobs:
           git add -A
           git commit -m "chore: release v${VERSION}"
           git tag -a "v${VERSION}" -m "geohazardwatch v${VERSION}"
-          git push --follow-tags origin main
+
+          # Race-safe push: if another commit landed on main between checkout
+          # and push, rebase the release commit on top of origin/main and retry.
+          # The annotated tag points at a specific SHA, so it must be dropped
+          # before rebase and re-created after, otherwise --follow-tags would
+          # push a tag pointing at an orphan commit.
+          for attempt in 1 2; do
+            if git push --follow-tags origin main; then
+              exit 0
+            fi
+            echo "Push rejected; rebasing on origin/main and retrying (attempt ${attempt})"
+            git fetch origin main
+            git tag -d "v${VERSION}"
+            git rebase origin/main
+            git tag -a "v${VERSION}" -m "geohazardwatch v${VERSION}"
+          done
+
+          echo "Push still rejected after rebase + retry; failing." >&2
+          exit 1


### PR DESCRIPTION
## Summary

- `auto-tag.yml` push step now rebases on `origin/main` and retries once if the push is rejected as non-fast-forward
- Annotated tag is dropped before rebase and re-created after, so `--follow-tags` pushes a tag pointing at the actual `main` tip rather than an orphan
- Fails loudly after the second attempt rather than masking a persistent conflict

## Why

Hit live on 2026-05-12 when #37 and #38 squash-merged within seconds. #37 fired `auto-tag.yml`; #38 landed on `main` while the workflow was running; the workflow's push was rejected as non-fast-forward. `v1.2.8` tag was pushed (tag pushes aren't subject to the FF rule) but pointed at an orphan release commit, and `main` was left at v1.2.7. Manual recovery (cherry-pick) followed in `9bc992e`.

The race window is ~30s in a typical run — rare today (single-operator repo) but will get more common as Renovate auto-merges become routine, which is the deployment model `addon-development-guide.md` §12 actively promotes.

## What changed

```diff
-          git push --follow-tags origin main
+
+          # Race-safe push: if another commit landed on main between checkout
+          # and push, rebase the release commit on top of origin/main and retry.
+          # The annotated tag points at a specific SHA, so it must be dropped
+          # before rebase and re-created after, otherwise --follow-tags would
+          # push a tag pointing at an orphan commit.
+          for attempt in 1 2; do
+            if git push --follow-tags origin main; then
+              exit 0
+            fi
+            echo "Push rejected; rebasing on origin/main and retrying (attempt ${attempt})"
+            git fetch origin main
+            git tag -d "v${VERSION}"
+            git rebase origin/main
+            git tag -a "v${VERSION}" -m "geohazardwatch v${VERSION}"
+          done
+
+          echo "Push still rejected after rebase + retry; failing." >&2
+          exit 1
```

The `actions/checkout` step already uses `fetch-depth: 0`, so the rebase has full history to work with.

## Test plan

- [ ] Merge a no-op PR that touches `package.json` to fire `auto-tag.yml`; confirm happy-path push still works on the first attempt and produces a `v*` tag pointing at the tip of `main`
- [ ] (Hard to repro deterministically) Merge two PRs within ~5s of each other where the first touches `package.json`; confirm both commits end up on `main` and exactly one `v*` tag is created pointing at the second-to-tip commit (the rebased release commit)
- [ ] Confirm `publish-image.yml` still triggers from the tag push (no change to the trigger contract — addon-development-guide.md §12's "every `v*` tag builds an image" still holds)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)