### PR TITLE
chore(deps): bump ngdpbase base 3.14.5→3.24.4 + Renovate customManager for the ARG pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # without rebuilding.
 
 # renovate: datasource=docker depName=ghcr.io/jwilleke/ngdpbase
-ARG NGDPBASE_VERSION=3.14.5
+ARG NGDPBASE_VERSION=3.24.4
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"

--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,7 @@
       "enabled": false
     },
     {
-      "description": "Auto-merge minor and patch updates for the ngdpbase base image",
-      "matchManagers": ["dockerfile"],
+      "description": "Auto-merge minor and patch updates for the ngdpbase base image (manager-agnostic: it is detected by the customManager regex below, not the dockerfile manager)",
       "matchPackageNames": ["ghcr.io/jwilleke/ngdpbase"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
@@ -26,7 +25,6 @@
     },
     {
       "description": "Major bumps of the ngdpbase base image require manual review",
-      "matchManagers": ["dockerfile"],
       "matchPackageNames": ["ghcr.io/jwilleke/ngdpbase"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
@@ -46,6 +44,18 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["dependencies", "major-bump", "needs-review"]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the ngdpbase base image pinned via the annotated `ARG NGDPBASE_VERSION`. Renovate's built-in dockerfile manager cannot follow a `FROM` whose tag is an ARG variable, so without this the pin silently froze (it was stuck at 3.14.5 while ngdpbase shipped 3.24.x — jwilleke/ngdpbase#751).",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+ARG NGDPBASE_VERSION=(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "{{{datasource}}}",
+      "versioningTemplate": "semver"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Why

GeoHazardWatch reports **ngdpbase v3.14.5** while upstream is **v3.24.4** — the recurring drift in jwilleke/ngdpbase#751.

Root cause is **here**, not in ngdpbase or Flux:

- ngdpbase correctly publishes `ghcr.io/jwilleke/ngdpbase:{X.Y.Z, X.Y, X}` on every release tag.
- Flux (`mj-infra-flux`) correctly auto-tracks the newest `ghcr.io/jwilleke/geohazardwatch:1.x` via its `ImagePolicy`/`ImageUpdateAutomation`.
- **But** our `Dockerfile` pins the base via an annotated `ARG NGDPBASE_VERSION`, and Renovate's built-in **dockerfile manager can't follow an ARG-interpolated `FROM` tag**. So the existing auto-merge packageRule never fired (no PR was ever opened), and the pin froze at 3.14.5. Every geohazardwatch image — including the one Flux is happily deploying — was built `FROM ghcr.io/jwilleke/ngdpbase:3.14.5`.

## Changes

- **Dockerfile**: `ARG NGDPBASE_VERSION` `3.14.5` → `3.24.4` (current ngdpbase) — makes the next image build current immediately.
- **renovate.json**: add a `customManagers` regex that matches the annotated `# renovate: datasource=docker depName=… ` + `ARG NGDPBASE_VERSION=…` pair (datasource=docker, semver versioning). Verified with the JS regex engine: captures `datasource=docker`, `depName=ghcr.io/jwilleke/ngdpbase`, `currentValue=3.24.4`.
- **renovate.json**: drop `matchManagers: ["dockerfile"]` from the two ngdpbase packageRules (keep `matchPackageNames`) so the existing minor/patch auto-merge + major-review rules apply to the customManager-detected dep regardless of which manager finds it.

## Effect

Renovate will now open ngdpbase base-image bump PRs and **auto-merge minor/patch** (major → `needs-review`). CI rebuilds the geohazardwatch image; the existing Flux `ImageUpdateAutomation` deploys it. The 3.14.5-vs-3.24 drift loop is closed permanently — no Flux or ngdpbase change needed.

Refs jwilleke/ngdpbase#751