### PR TITLE
fix(#61): drop redundant customManager that collided with dockerfile manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-# renovate: datasource=docker depName=ghcr.io/jwilleke/ngdpbase
 ARG NGDPBASE_VERSION=3.24.4
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
   "rangeStrategy": "bump",
   "packageRules": [
     {
-      "description": "Auto-merge minor and patch updates for the ngdpbase base image (manager-agnostic: it is detected by the customManager regex below, not the dockerfile manager)",
+      "description": "Auto-merge minor and patch updates for the ngdpbase base image",
+      "matchManagers": ["dockerfile"],
       "matchPackageNames": ["ghcr.io/jwilleke/ngdpbase"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
@@ -19,6 +20,7 @@
     },
     {
       "description": "Major bumps of the ngdpbase base image require manual review",
+      "matchManagers": ["dockerfile"],
       "matchPackageNames": ["ghcr.io/jwilleke/ngdpbase"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
@@ -38,18 +40,6 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["dependencies", "major-bump", "needs-review"]
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Track the ngdpbase base image pinned via the annotated `ARG NGDPBASE_VERSION`. Renovate's built-in dockerfile manager cannot follow a `FROM` whose tag is an ARG variable, so without this the pin silently froze (it was stuck at 3.14.5 while ngdpbase shipped 3.24.x — jwilleke/ngdpbase#751).",
-      "fileMatch": ["(^|/)Dockerfile$"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+ARG NGDPBASE_VERSION=(?<currentValue>\\S+)"
-      ],
-      "datasourceTemplate": "{{{datasource}}}",
-      "versioningTemplate": "semver"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Removes the `customManagers` regex entry from `renovate.json` and the matching `# renovate: …` annotation from `Dockerfile`.
- Restores `"matchManagers": ["dockerfile"]` on the two ngdpbase package rules so the built-in dockerfile manager is the sole source of truth.

## Why

Closes #61.

PR #54 added a regex `customManager` because, historically, Renovate's `dockerfile` manager couldn't follow a `FROM` whose tag is an ARG variable. That changed: current Renovate (v46.1.14 in this repo's self-hosted workflow) resolves `ARG X=ver` + `FROM image:${X}` natively.

Effect of having both: Renovate's manager stats from run [`26340236086`](https://github.com/jwilleke/geohazardwatch/actions/runs/26340236086) show both managers matching the same dep:

```
dockerfile: {fileCount: 1, depCount: 1}
regex:      {fileCount: 2, depCount: 2}
```

Both produce updates targeting the same depName → same branch (`renovate/ghcr.io-jwilleke-ngdpbase-3.x`). One wins the push, the other then logs `Cannot find replaceString in current file content` and bails. The branch ended up stuck on `3.39.2` with no PR ever opened, while main stayed pinned at `3.24.4` and upstream shipped through `3.39.3`.

After this change there's a single manager for the ngdpbase image, which restores the same branch → PR → auto-merge flow that already works for npm bumps in this repo.

## Test plan

- [ ] On next scheduled Renovate run (cron `0 */6 * * *`), confirm a PR opens against main bumping `NGDPBASE_VERSION` from `3.24.4` toward the latest ghcr.io tag (currently `3.39.3`). Manually trigger via `gh workflow run renovate.yml` if needed.
- [ ] Confirm `ci.yml` fires on the new PR (it triggers on `pull_request: branches: [main]`).
- [ ] Confirm `platformAutomerge` merges the PR once checks pass (per the minor/patch rule).
- [ ] After merge, confirm `auto-tag.yml` → `publish-image.yml` cascade fires as expected.
- [ ] Delete the stuck `renovate/ghcr.io-jwilleke-ngdpbase-3.x` branch so Renovate recreates fresh (otherwise it may attempt another `replaceString` patch on stale content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)