### PR TITLE
chore: bump ngdpbase base image to v3.39.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-ARG NGDPBASE_VERSION=3.24.4
+ARG NGDPBASE_VERSION=3.39.3
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"


### PR DESCRIPTION
## Summary
- Bumps `NGDPBASE_VERSION` in `Dockerfile` from `3.24.4` → `3.39.3`
- Production site footer at https://geohazardwatch.com/view/SystemInfo was showing `v3.24.4` because the footer template renders `{\$version}` from the ngdpbase host, which is the base image version
- v3.39.3 is the latest released ngdpbase tag

## Test plan
- [ ] CI passes (lint, addon-rename detector)
- [ ] Container publish workflow builds `geohazardwatch:v1.2.X` on the new base
- [ ] After deploy, `/view/SystemInfo` footer shows `v3.39.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)