### PR TITLE
chore(deps): bump ngdpbase base image 3.49.0 → 3.49.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-ARG NGDPBASE_VERSION=3.49.0
+ARG NGDPBASE_VERSION=3.49.1
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"


### PR DESCRIPTION
Bumps `ARG NGDPBASE_VERSION` 3.49.0 → 3.49.1 (`ghcr.io/jwilleke/ngdpbase:3.49.1`, published today).

Why: the 3.49.0 base image was built 2026-06-08, before the June-16 dependency/security wave. 3.49.1 picks up:

- nodemailer 9.0.1, undici 6.27, js-yaml 3.15, multer 2.2.0, protobufjs override (June wave)
- systeminformation 5.31.17 — CVE-2026-50289, high (fixed 2026-07-16, ngdpbase#858)
- import-preview error-surfacing fix (ngdpbase#815) and markdown-lint CI fixes

Also clears the stale Trivy image alerts on the ngdpbase side (scanned image predated the fixes).

Same shape as Renovate's minor/patch bumps (auto-merge policy per renovate.json); manual because the release is minutes old.

🤖 Generated with [Claude Code](https://claude.com/claude-code)