### PR TITLE
chore(deps): bump ngdpbase base image 3.49.1 → 3.50.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-ARG NGDPBASE_VERSION=3.49.1
+ARG NGDPBASE_VERSION=3.50.0
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"


### PR DESCRIPTION
Bumps `ARG NGDPBASE_VERSION` 3.49.1 → 3.50.0 (`ghcr.io/jwilleke/ngdpbase:3.50.0`, published today, docker-build green).

Ships to this instance:

- feeds **xml adapter** (fast-xml-parser) — XML-only sources become config-only (relevant to #5)
- **DataFeed `badge=` / `link=`** — activates the color pills + GVP volcano links already configured on the [VONA page](https://geohazardwatch.com/view/Volcanic%20Ash%20Advisories%20(VONA))
- feeds docs + Using FeedManager seed page

Manual bump ahead of Renovate's next cycle (same shape as its auto minor bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)