### PR TITLE
chore(deps): bump ngdpbase base image to 3.61.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
 
-ARG NGDPBASE_VERSION=3.60.0
+ARG NGDPBASE_VERSION=3.61.0
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"


### PR DESCRIPTION
Bumps `ARG NGDPBASE_VERSION` 3.60.0 → **3.61.0** (`ghcr.io/jwilleke/ngdpbase:3.61.0`, image build succeeded).

## What this pulls in
- **#920 (core)** — content-aware, edit-preserving addon **page reseed**: addon page *updates* now propagate to this instance on restart (previously only new pages did). ⚠️ Opt-in — also set `ngdpbase.addons.page-reseed: true` in the instance config (default off) for it to run; unmodified pages only, operator edits never clobbered.
- **#869 / #915** — keyword normalizer + dedup enforcement + explicit-add typeahead.
- **#883** — suggested keyword sets in the editor.
- **#914** — body-parser 2.3.0 in addon lockfiles (DoS fix).
- Plus the addon-page-handling docs.

## Notes
- Renovate would reach 3.61.0 on its own in due time; this expedites it.
- After merge: rebuild the geohazardwatch image + restart the deployment to run on 3.61.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)