### PR TITLE
feat: migrate to the packaged (npm) addon model

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -28,6 +28,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up Node.js for addon publish
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.18.0'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@jwilleke'
+
+      - name: Publish @jwilleke/geohazardwatch-addon
+        working-directory: addons/geohazardwatch
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve addon version for image build
+        id: addon_version
+        run: echo "version=$(node -p "require('./addons/geohazardwatch/package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -65,6 +82,10 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GEOHAZARDWATCH_ADDON_VERSION=${{ steps.addon_version.outputs.version }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@jwilleke:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,9 @@ ngdpbase runs on port 3333. Admin panel at `/admin`, pages at `/view/<slug>`.
 
 ### How the addon loads
 
-ngdpbase's `AddonsManager` discovers addons via the `addons-path` config key, finds `addons/geohazardwatch/index.js`, and calls `module.exports.register(engine, config)`. The `engine` object provides access to all ngdpbase managers and the Express app.
+**Local development (drop-in):** ngdpbase's `AddonsManager` discovers addons via the `addons-path` config key, finds `addons/geohazardwatch/index.js`, and calls `module.exports.register(engine, config)`. The `engine` object provides access to all ngdpbase managers and the Express app.
+
+**Production (packaged):** the addon is also published as an npm package, `@jwilleke/geohazardwatch-addon` (see `addons/geohazardwatch/package.json`), installed into a generic `ghcr.io/jwilleke/ngdpbase` image via `Dockerfile`'s `npm install` line. A `node_modules:@jwilleke/*-addon` entry in the instance's `addons-path` config discovers it from `node_modules` instead of a directory — same `register()` contract, only the discovery mechanism differs. This decouples the addon's version from the ngdpbase base-image version ([#152](https://github.com/jwilleke/geohazardwatch/issues/152), following ngdpbase's [addon-packaged.md](https://github.com/jwilleke/ngdpbase/blob/master/docs/platform/deployment/addon-packaged.md)). The published package's version is kept in lockstep with the repo's own version by `src/utils/version.ts`.
 
 ```
 ngdpbase/src/managers/AddonsManager.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
-# geohazardwatch — ngdpbase + geohazardwatch addon
+# syntax=docker/dockerfile:1.4
+
+# geohazardwatch — ngdpbase + geohazardwatch addon (packaged/npm model, #152)
 #
-# Layered on top of the upstream ngdpbase image. The geohazardwatch addon code
-# is copied into /opt/geohazardwatch/ and registered with ngdpbase via the
-# addons-path config setting (set in the runtime ConfigMap, not here).
+# The geohazardwatch addon ships as a published npm package
+# (@jwilleke/geohazardwatch-addon) rather than being copied into the image.
+# This keeps the ngdpbase base-image pin (NGDPBASE_VERSION, above) and the
+# addon package pin on independent, Renovate-tracked versions — see
+# ngdpbase's docs/platform/deployment/addon-packaged.md.
 #
 # Imported volcano/quake/HANS data lives on a persistent volume mounted at
 # /app/data — NOT baked into the image — so a CronJob can refresh it
 # without rebuilding.
+#
+# NOTE: the running instance's addons-path config (app-custom-config.json,
+# set via the runtime ConfigMap, not here) must include
+# "node_modules:@jwilleke/*-addon" for this image to actually load the addon.
 
 ARG NGDPBASE_VERSION=3.63.0
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
@@ -16,18 +24,17 @@ LABEL org.opencontainers.image.description="Volcano and geology platform built o
 LABEL org.opencontainers.image.source="https://github.com/jwilleke/geohazardwatch"
 LABEL org.opencontainers.image.licenses="MIT"
 
-WORKDIR /opt/geohazardwatch
-
-COPY package.json package-lock.json ./
-
-# --ignore-scripts skips the `prepare` lifecycle (husky install). Husky is a
-# devDependency that isn't present under --omit=dev, and the resulting
-# `husky: not found` makes npm ci exit 127. We don't need git hooks in a
-# runtime container.
-RUN npm ci --omit=dev --ignore-scripts
-
-COPY addons ./addons
-COPY src ./src
-COPY tools ./tools
-
 WORKDIR /app
+
+ARG GEOHAZARDWATCH_ADDON_VERSION
+COPY .npmrc ./
+
+# Installs the addon as an ordinary npm dependency into /app/node_modules,
+# where ngdpbase's `node_modules:@jwilleke/*-addon` addons-path glob finds
+# it. The GitHub token is mounted only for this RUN step (BuildKit secret)
+# and is never written to an image layer; .npmrc is removed in the same
+# layer once the install completes.
+RUN --mount=type=secret,id=github_token \
+    NODE_AUTH_TOKEN="$(cat /run/secrets/github_token)" \
+    npm install "@jwilleke/geohazardwatch-addon@${GEOHAZARDWATCH_ADDON_VERSION}" --omit=dev && \
+    rm -f .npmrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # set via the runtime ConfigMap, not here) must include
 # "node_modules:@jwilleke/*-addon" for this image to actually load the addon.
 
-ARG NGDPBASE_VERSION=3.63.0
+ARG NGDPBASE_VERSION=3.64.0
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"

--- a/SETUP.md
+++ b/SETUP.md
@@ -33,7 +33,7 @@ Data is written to `addons/geohazardwatch/data/` (gitignored). Re-run any time t
 
 ## Step 3 — Wire to ngdpbase
 
-Add to `$FAST_STORAGE/config/app-custom-config.json` on your ngdpbase instance:
+This is the **drop-in** path — the right choice for local development (edit-in-place, no publish step). Add to `$FAST_STORAGE/config/app-custom-config.json` on your ngdpbase instance:
 
 ```json
 {
@@ -42,6 +42,8 @@ Add to `$FAST_STORAGE/config/app-custom-config.json` on your ngdpbase instance:
   "ngdpbase.addons.geohazardwatch.dataPath": "./data/geohazardwatch"
 }
 ```
+
+> Production instead installs the addon as a versioned npm package (`@jwilleke/geohazardwatch-addon`) into a generic ngdpbase image — see `Dockerfile` and [#152](https://github.com/jwilleke/geohazardwatch/issues/152). That config uses `"node_modules:@jwilleke/*-addon"` in `addons-path` instead of a directory path. Local dev keeps using drop-in as shown above.
 
 ## Step 4 — Restart ngdpbase
 

--- a/addons/geohazardwatch/README.md
+++ b/addons/geohazardwatch/README.md
@@ -342,6 +342,12 @@ The Tsunami and Landslide pages render live data through a separate ngdpbase `fe
 
 ---
 
+## Distribution
+
+This directory is also published as an npm package, `@jwilleke/geohazardwatch-addon` (see `package.json` in this directory), for production deployment — see [`../../Dockerfile`](../../Dockerfile) and [geohazardwatch#152](https://github.com/jwilleke/geohazardwatch/issues/152). Local development still uses **drop-in** (this directory referenced directly via `addons-path`, as in [SETUP.md](../../SETUP.md)); only the production image installs it as a versioned dependency instead of copying the directory. The addon's own runtime code, `register()` contract, and config keys are identical either way.
+
+---
+
 ## Structure
 
 ```

--- a/addons/geohazardwatch/package.json
+++ b/addons/geohazardwatch/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@jwilleke/geohazardwatch-addon",
+  "version": "1.2.100",
+  "description": "Volcano & geology data platform add-on for ngdpbase — GVP structured records, search, infoboxes, maps",
+  "main": "index.js",
+  "ngdpbase": {
+    "slug": "geohazardwatch",
+    "type": "domain"
+  },
+  "files": [
+    "config",
+    "import",
+    "managers",
+    "pages",
+    "plugins",
+    "public",
+    "routes",
+    "views",
+    "index.js",
+    "README.md"
+  ],
+  "dependencies": {
+    "express": "^5.2.1"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jwilleke/geohazardwatch.git",
+    "directory": "addons/geohazardwatch"
+  },
+  "author": "jwilleke",
+  "license": "MIT"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,20 @@
 {
   "name": "geohazardwatch",
-  "version": "1.2.82",
+  "version": "1.2.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geohazardwatch",
-      "version": "1.2.82",
+      "version": "1.2.100",
       "license": "MIT",
-      "dependencies": {
-        "express": "^5.2.1",
-        "leaflet": "^1.9.4"
-      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.9.5",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^10.7.0",
+        "express": "^5.2.1",
         "globals": "^17.7.0",
         "husky": "^9.1.7",
         "markdownlint-cli": "^0.49.1",
@@ -952,6 +949,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -1035,6 +1033,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -1059,6 +1058,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1085,6 +1085,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1094,6 +1095,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1107,6 +1109,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1166,6 +1169,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1179,6 +1183,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1188,6 +1193,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1197,6 +1203,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -1221,6 +1228,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1269,6 +1277,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1302,6 +1311,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -1316,12 +1326,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1344,6 +1356,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1353,6 +1366,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1362,6 +1376,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1416,6 +1431,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -1626,6 +1642,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1635,6 +1652,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -1730,6 +1748,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1789,6 +1808,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1798,6 +1818,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1822,6 +1843,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1844,6 +1866,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1868,6 +1891,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -1907,6 +1931,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1919,6 +1944,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1931,6 +1957,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1943,6 +1970,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -1979,6 +2007,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2015,6 +2044,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -2031,6 +2061,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -2111,6 +2142,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -2217,12 +2249,6 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
-    },
-    "node_modules/leaflet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2357,6 +2383,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2373,6 +2400,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2382,6 +2410,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2930,6 +2959,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2939,6 +2969,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -2981,6 +3012,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -2994,6 +3026,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3003,6 +3036,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3015,6 +3049,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -3027,6 +3062,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3106,6 +3142,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3135,6 +3172,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3184,6 +3222,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -3217,6 +3256,7 @@
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -3233,6 +3273,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3246,6 +3287,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -3261,6 +3303,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -3293,6 +3336,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3312,6 +3356,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -3338,6 +3383,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -3357,6 +3403,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -3386,6 +3433,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3405,6 +3453,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3421,6 +3470,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -3439,6 +3489,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -3471,6 +3522,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3543,6 +3595,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -3597,6 +3650,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -3615,6 +3669,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3656,6 +3711,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3675,6 +3731,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3710,6 +3767,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -23,16 +23,13 @@
     "prepare": "husky install",
     "version:bump": "tsx src/utils/version.ts"
   },
-  "dependencies": {
-    "express": "^5.2.1",
-    "leaflet": "^1.9.4"
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.9.5",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
     "eslint": "^10.7.0",
+    "express": "^5.2.1",
     "globals": "^17.7.0",
     "husky": "^9.1.7",
     "markdownlint-cli": "^0.49.1",

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -5,6 +5,7 @@
  * Updates the version consistently across:
  *   - package.json
  *   - addons/geohazardwatch/index.js
+ *   - addons/geohazardwatch/package.json  (the published @jwilleke/geohazardwatch-addon package)
  *   - CHANGELOG.md  (prepends a new [x.y.z] section)
  *
  * Usage:
@@ -79,6 +80,14 @@ function updateIndexJs(next: string): void {
   console.log(`  addons/geohazardwatch/index.js  ${next}`);
 }
 
+function updateAddonPackageJson(next: string): void {
+  const rel = 'addons/geohazardwatch/package.json';
+  const pkg = JSON.parse(readFile(rel)) as Record<string, unknown>;
+  pkg.version = next;
+  writeFile(rel, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(`  addons/geohazardwatch/package.json  ${next}`);
+}
+
 function updateChangelog(next: string, prev: string): void {
   const rel = 'CHANGELOG.md';
   const content = readFile(rel);
@@ -125,6 +134,7 @@ function main(): void {
   console.log(`\nBumping ${prev} → ${next}\n`);
   updatePackageJson(next);
   updateIndexJs(next);
+  updateAddonPackageJson(next);
   updateChangelog(next, prev);
 
   console.log(`\nNext steps:`);


### PR DESCRIPTION
## Summary

Implements #152 — migrates geohazardwatch from the **drop-in** addon model (bespoke `FROM ngdpbase + COPY addons` image) to the **packaged** model recommended for `type: 'domain'` addons ([ngdpbase#673](https://github.com/jwilleke/ngdpbase/issues/673), shipped in v3.63.0): the addon ships as a published npm package installed into a generic ngdpbase image.

- `addons/geohazardwatch/package.json` (new): publishable manifest for `@jwilleke/geohazardwatch-addon` — `ngdpbase: {slug: "geohazardwatch", type: "domain"}`, `express` as its own dependency (only actual runtime npm dep — `leaflet` is vendored as a static asset, not `require()`'d).
- `Dockerfile`: collapsed to `FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}` + one authenticated `npm install "@jwilleke/geohazardwatch-addon@${GEOHAZARDWATCH_ADDON_VERSION}"`. Auth uses a BuildKit `--mount=type=secret` — the GitHub token never touches an image layer. Verified locally: builds correctly, `.npmrc` is absent from the final image, no token in `docker history`.
- `.github/workflows/publish-image.yml`: publishes the addon package to GitHub Packages *before* the Docker build, then passes its version + the publish token through as a build-arg/secret so the build can install the exact version just published.
- `src/utils/version.ts`: added a 5th updater so `addons/geohazardwatch/package.json`'s version stays in lockstep with the repo version on every future `version:bump`.
- Root `package.json`: dropped the unused `leaflet` dependency, moved `express` to `devDependencies` (still resolves for local **drop-in** dev; no longer needed in the production image now that the addon package supplies its own).
- Docs (`AGENTS.md`, `SETUP.md`, addon `README.md`): describe packaged (production) vs. drop-in (local dev) side by side — drop-in is unchanged for development.

Versioning design: this stays a single shared repo version rather than two independent release trains — the addon and the Dockerfile/app already release together via `auto-tag.yml`. The genuine independence axis that caused the [ngdpbase#672](https://github.com/jwilleke/ngdpbase/issues/672) outage — addon pin vs. **ngdpbase base-image** pin — is unaffected; that's still tracked independently via the Dockerfile's `ARG NGDPBASE_VERSION` and Renovate.

## ⚠️ Required before merging

- [ ] **Production's `app-custom-config.json` (Kubernetes ConfigMap, outside this repo) must add `"node_modules:@jwilleke/*-addon"` to `addons-path`** before this merges/rolls out. The current thin image no longer contains `addons/` copied in at a directory path — if the image rolls before the ConfigMap changes, the geohazardwatch addon (every page/plugin/route) silently stops loading. This repo has no access to that ConfigMap, so it isn't (and can't be) part of this PR.
- [ ] Once the ConfigMap is ready: merge this PR, which will auto-tag a release (`auto-tag.yml`) → publish `@jwilleke/geohazardwatch-addon` to GitHub Packages → build + push the new thin image — the first time this pipeline runs end-to-end.

## Test plan

- [x] `npm run lint` / `npx tsc --noEmit` pass
- [x] Local `docker buildx build` against the new Dockerfile confirms: syntax/secret-mount mechanics work, `.npmrc` routes to `npm.pkg.github.com` correctly (404 only because the package doesn't exist yet — expected, not published this session), and a throwaway test with a real installable package confirmed `.npmrc` is absent from the final image with no token leakage in `docker history`
- [ ] After merge: confirm `publish-image.yml` runs end-to-end (addon publish → image build → smoke test → Trivy scan all green)
- [ ] After deploy: confirm production still serves all geohazardwatch pages/plugins post-rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)