### PR TITLE
fix(#177): align seeded pages with ngdpbase addon decisions (§9/§10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ External API (GVP WFS / USGS / HANS)
   → routes/api.js                (REST endpoints for client-side widgets)
 ```
 
-The Tsunami and Landslide pages (`pages/Tsunamis.md`, `pages/Landslides.md`) are a separate, content-only path: they carry no import script or data manager in this repo. They render live data via `[{DataFeed source='...'}]` markup, a plugin provided by ngdpbase's own `feeds` addon ([ngdpbase#685](https://github.com/jwilleke/ngdpbase/issues/685)), configured independently in the instance's `app-custom-config.json`. See [Key Decisions](#key-decisions) and the page files themselves for the feed source config.
+The Tsunami and Landslide pages (`pages/tsunamis.md`, `pages/landslides.md`) are a separate, content-only path: they carry no import script or data manager in this repo. They render live data via `[{DataFeed source='...'}]` markup, a plugin provided by ngdpbase's own `feeds` addon ([ngdpbase#685](https://github.com/jwilleke/ngdpbase/issues/685)), configured independently in the instance's `app-custom-config.json`. See [Key Decisions](#key-decisions) and the page files themselves for the feed source config.
 
 ### Plugin system
 
@@ -161,7 +161,7 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for repo structure, data pipeline depth
 - **Pages seeded, never overwritten** — `seedAddonPages()` in ngdpbase copies `.md` files from `pages/` on first load only. User edits are preserved.
 - **HansDataManager loads silently if `activity.json` is absent** — HANS data is optional; the addon starts cleanly without it.
 - **ESLint config targets TS but addon code is JS** — `.eslintrc.json` is from the project template and is wired for future TS work. Current `lint:code` targets `addons/**/*.js` with plain JS linting rules only.
-- **Tsunami/Landslide pages depend on an addon this repo does not own** — `pages/Tsunamis.md` and `pages/Landslides.md` render live data through `[{DataFeed}]` markup from ngdpbase's `feeds` addon ([ngdpbase#685](https://github.com/jwilleke/ngdpbase/issues/685)). If that addon is absent or its `tsunami-alerts` / `landslide-events` sources aren't configured, the pages fall back to static informational content — geohazardwatch never fetches or stores this data itself. Field mappings (esp. NASA COOLR) should be re-verified against the live upstream schema before relying on them.
+- **Tsunami/Landslide pages depend on an addon this repo does not own** — `pages/tsunamis.md` and `pages/landslides.md` render live data through `[{DataFeed}]` markup from ngdpbase's `feeds` addon ([ngdpbase#685](https://github.com/jwilleke/ngdpbase/issues/685)). If that addon is absent or its `tsunami-alerts` / `landslide-events` sources aren't configured, the pages fall back to static informational content — geohazardwatch never fetches or stores this data itself. Field mappings (esp. NASA COOLR) should be re-verified against the live upstream schema before relying on them.
 - **`type` vs `schemaType` on DataFeed sources** — `schemaType` stays `Article` for these two feeds until ngdpbase implements the `WarningAlert`/`Event` schema.org union types ([ngdpbase#762](https://github.com/jwilleke/ngdpbase/issues/762)); `type` carries the intended domain label in the meantime.
 
 ## Open Issues

--- a/addons/geohazardwatch/README.md
+++ b/addons/geohazardwatch/README.md
@@ -377,16 +377,16 @@ addons/geohazardwatch/
 │   ├── import-earthquakes.js       ← USGS feed importer + proximity matching
 │   └── import-hans.js              ← USGS HANS alert importer
 ├── pages/                          ← Seeded into ngdpbase on first load, never overwritten
-│   ├── geohazardwatch-home.md
+│   ├── volcanoes-and-earthquakes.md
 │   ├── geohazardwatch-about.md
-│   ├── geohazardwatch-volcanoes.md
-│   ├── geohazardwatch-earthquakes.md
-│   ├── geohazardwatch-hans.md
-│   ├── geohazardwatch-demo.md
-│   ├── geohazardwatch-japan.md
+│   ├── volcanoes.md
+│   ├── earthquakes.md
+│   ├── us-volcano-alerts-usgs-hans.md
+│   ├── geology-demo.md
+│   ├── japan-volcanoes.md
 │   ├── geohazardwatch-plugins.md
-│   ├── Tsunamis.md                ← Content-only; live via ngdpbase `feeds` addon
-│   ├── Landslides.md               ← Content-only; live via ngdpbase `feeds` addon
+│   ├── tsunamis.md                ← Content-only; live via ngdpbase `feeds` addon
+│   ├── landslides.md               ← Content-only; live via ngdpbase `feeds` addon
 │   ├── left-menu-content.md
 │   └── footer-content.md
 ├── public/
@@ -399,7 +399,7 @@ addons/geohazardwatch/
 
 ## Tsunami & Landslide pages
 
-`pages/Tsunamis.md` and `pages/Landslides.md` are seeded like any other page, but they carry no import script or data manager in this repo. They render live data with `[{DataFeed source='...'}]` markup — a plugin supplied by ngdpbase's own `feeds` addon ([ngdpbase#685](https://github.com/jwilleke/ngdpbase/issues/685)), not by geohazardwatch.
+`pages/tsunamis.md` and `pages/landslides.md` are seeded like any other page, but they carry no import script or data manager in this repo. They render live data with `[{DataFeed source='...'}]` markup — a plugin supplied by ngdpbase's own `feeds` addon ([ngdpbase#685](https://github.com/jwilleke/ngdpbase/issues/685)), not by geohazardwatch.
 
 To make the feeds render, enable the `feeds` addon and declare its sources in the instance's `app-custom-config.json`:
 

--- a/addons/geohazardwatch/pages/alerts.md
+++ b/addons/geohazardwatch/pages/alerts.md
@@ -2,7 +2,7 @@
 title: Alerts
 uuid: db1a542e-71e2-489a-80ff-4b5b022a2bf6
 slug: alerts
-system-category: addon
+system-category: general
 description: Everything currently active and dangerous across volcanoes, tsunamis, and volcanic ash — one page, all hazard types
 tags: [geology, alerts, volcanoes, tsunamis, hans, vaac]
 author: system

--- a/addons/geohazardwatch/pages/attribution.md
+++ b/addons/geohazardwatch/pages/attribution.md
@@ -2,7 +2,7 @@
 title: Attribution
 uuid: efaa8c71-593a-4155-84cd-04c770bc5247
 slug: attribution
-system-category: addon
+system-category: documentation
 description: Credit and citation for every data source geohazardwatch imports, links to, or displays
 tags: [attribution, credits, data-sources, licensing, gvp, usgs, nasa, noaa]
 author: system

--- a/addons/geohazardwatch/pages/earthquakes.md
+++ b/addons/geohazardwatch/pages/earthquakes.md
@@ -2,6 +2,7 @@
 title: Earthquakes
 uuid: ac0ce090-ddae-44cc-b5e8-0d9c5922e5dc
 slug: earthquakes
+system-category: general
 author: system
 user-keywords:
   - earthquakes

--- a/addons/geohazardwatch/pages/footer-content.md
+++ b/addons/geohazardwatch/pages/footer-content.md
@@ -2,7 +2,7 @@
 title: Footer Content
 uuid: 2b04424b-5541-41e5-b85c-dee161f66945
 slug: footer-content
-system-category: addon
+system-category: system
 addon: geohazardwatch
 author: geohazardwatch
 ---

--- a/addons/geohazardwatch/pages/geohazardwatch-about.md
+++ b/addons/geohazardwatch/pages/geohazardwatch-about.md
@@ -2,6 +2,7 @@
 title: About geohazardwatch
 uuid: 98f2df76-5d86-472a-9862-9a01267cf4a7
 slug: geohazardwatch-about
+system-category: documentation
 description: What geohazardwatch is, where the data comes from, and how to interpret data freshness
 tags: [geology, about, data-sources, volcanoes, earthquakes]
 author: system

--- a/addons/geohazardwatch/pages/geohazardwatch-plugins.md
+++ b/addons/geohazardwatch/pages/geohazardwatch-plugins.md
@@ -2,6 +2,7 @@
 title: Plugin Guide
 uuid: 93595dc0-1ba1-422a-9fd4-c2f6bf056b27
 slug: geohazardwatch-plugins
+system-category: general
 description: End-user guide to all geohazardwatch plugins — what they render, how to use them, and common combinations
 tags: [geology, plugins, guide, volcanoes, earthquakes]
 author: system

--- a/addons/geohazardwatch/pages/geology-demo.md
+++ b/addons/geohazardwatch/pages/geology-demo.md
@@ -2,6 +2,7 @@
 title: Geology Demo
 uuid: 37a05b59-a793-4204-b389-f5e89fb80537
 slug: geology-demo
+system-category: general
 author: system
 user-keywords:
   - demo

--- a/addons/geohazardwatch/pages/japan-volcanoes.md
+++ b/addons/geohazardwatch/pages/japan-volcanoes.md
@@ -2,6 +2,7 @@
 title: Japan Volcanoes
 uuid: d72befb6-5596-4e7e-b0ca-5c95d7ff32c1
 slug: japan-volcanoes
+system-category: general
 author: system
 user-keywords:
   - Japan

--- a/addons/geohazardwatch/pages/landslides.md
+++ b/addons/geohazardwatch/pages/landslides.md
@@ -2,7 +2,7 @@
 title: Landslides
 uuid: e32456ef-4cfa-40ed-a20a-382aa81438b7
 slug: landslides
-system-category: addon
+system-category: general
 description: Landslide events, warnings, and historical catalog for geohazardwatch
 tags: [geology, landslides, mass-wasting, nasa, usgs]
 author: system

--- a/addons/geohazardwatch/pages/left-menu-content.md
+++ b/addons/geohazardwatch/pages/left-menu-content.md
@@ -2,7 +2,7 @@
 title: Left Menu Content
 uuid: 0c0cb715-a46c-4a91-9189-9e05b7f9e95f
 slug: left-menu-content
-system-category: addon
+system-category: system
 addon: geohazardwatch
 author: geohazardwatch
 ---

--- a/addons/geohazardwatch/pages/tsunamis.md
+++ b/addons/geohazardwatch/pages/tsunamis.md
@@ -2,7 +2,7 @@
 title: Tsunamis
 uuid: ee6ec3ff-b822-4d1d-beb2-0ea2d39603f1
 slug: tsunamis
-system-category: addon
+system-category: general
 description: Tsunami warnings, advisories, and historical events for geohazardwatch
 tags: [geology, tsunamis, ocean, noaa, usgs]
 author: system

--- a/addons/geohazardwatch/pages/us-volcano-alerts-usgs-hans.md
+++ b/addons/geohazardwatch/pages/us-volcano-alerts-usgs-hans.md
@@ -2,6 +2,7 @@
 title: US Volcano Alerts (USGS HANS)
 uuid: ea663c20-6809-4443-91ba-6cefbf48b2e1
 slug: us-volcano-alerts-usgs-hans
+system-category: general
 description: Real-time US volcano alert levels from the USGS Hazard Alert Notification System
 tags: [geology, volcanoes, alerts, usgs]
 ---

--- a/addons/geohazardwatch/pages/volcano-activity.md
+++ b/addons/geohazardwatch/pages/volcano-activity.md
@@ -2,7 +2,7 @@
 title: Volcano Activity
 uuid: 42fd6ec1-e8a6-4f0c-a21e-bb1a87483700
 slug: volcano-activity
-system-category: addon
+system-category: general
 description: Original volcanic activity news and eruption reports from VolcanoDiscovery — for VAAC ash advisories, see Alerts
 tags: [geology, volcanoes, volcanodiscovery]
 author: system

--- a/addons/geohazardwatch/pages/volcanoes-and-earthquakes.md
+++ b/addons/geohazardwatch/pages/volcanoes-and-earthquakes.md
@@ -2,7 +2,7 @@
 title: Volcanoes and Earthquakes
 uuid: 4bf246b9-ebcc-4774-8175-427c275d407c
 slug: volcanoes-and-earthquakes
-system-category: addon
+system-category: general
 description: Home page for the geohazardwatch volcano and earthquake data platform
 tags: [geology, volcanoes, earthquakes, home]
 author: system

--- a/addons/geohazardwatch/pages/volcanoes.md
+++ b/addons/geohazardwatch/pages/volcanoes.md
@@ -2,6 +2,7 @@
 title: Volcanoes
 uuid: 3b3828dd-590f-46fe-9030-d3306ed2ac98
 slug: volcanoes
+system-category: general
 author: system
 user-keywords:
   - volcanoes

--- a/addons/geohazardwatch/pages/wildfires.md
+++ b/addons/geohazardwatch/pages/wildfires.md
@@ -2,7 +2,7 @@
 title: Wildfires
 uuid: 8d673582-02e8-47fe-80fb-1e27ea98d34a
 slug: wildfires
-system-category: addon
+system-category: general
 description: Global wildfire thermal hotspots from NASA FIRMS/VIIRS
 tags: [geology, wildfires, fire, nasa, firms]
 author: system

--- a/docs/earthquake-sources.md
+++ b/docs/earthquake-sources.md
@@ -6,7 +6,7 @@ Not one of the four the user asked about by name, but the same treatment applies
 
 | Our pipeline | Upstream (real source) | Kind | Poll/import cadence | Rendered on |
 |---|---|---|---|---|
-| `EarthquakeDataManager` | `earthquake.usgs.gov/earthquakes/feed/v1.0/summary/<feed>.geojson` (USGS) | **Primary**, single source, no re-publishers involved | manual (`npm run import:earthquakes[:month]`) | `geohazardwatch-earthquakes.md`, EarthquakeList/Map plugins, `/api/geohazardwatch/*` |
+| `EarthquakeDataManager` | `earthquake.usgs.gov/earthquakes/feed/v1.0/summary/<feed>.geojson` (USGS) | **Primary**, single source, no re-publishers involved | manual (`npm run import:earthquakes[:month]`) | `earthquakes.md`, EarthquakeList/Map plugins, `/api/geohazardwatch/*` |
 
 USGS's own standard summary feeds — no third party in between, unlike the volcano-activity situation. Available feed variants (selectable via `--feed=`):
 

--- a/docs/landslides-sources.md
+++ b/docs/landslides-sources.md
@@ -4,9 +4,9 @@
 
 | Our pipeline | Upstream (real source) | Kind | Poll interval | Rendered on |
 |---|---|---|---|---|
-| `landslide-events` (ngdpbase `feeds` addon) | `maps.nccs.nasa.gov/.../COOLR/COOLR_Events_Point/FeatureServer` (NASA COOLR — Cooperative Open Online Landslide Repository) | **Primary**, single source, no bespoke code | daily at 06:00 | `Landslides.md` (`/view/landslides`) |
+| `landslide-events` (ngdpbase `feeds` addon) | `maps.nccs.nasa.gov/.../COOLR/COOLR_Events_Point/FeatureServer` (NASA COOLR — Cooperative Open Online Landslide Repository) | **Primary**, single source, no bespoke code | daily at 06:00 | `landslides.md` (`/view/landslides`) |
 
-No redundancy here — unlike volcano data, landslides have exactly one pipeline: a generic `geojson`-adapter `DataFeed` config entry pointed straight at NASA's own COOLR ArcGIS FeatureServer. There's no bespoke manager/plugin (`addons/geohazardwatch/managers/` and `plugins/` have nothing landslide-specific) — it's entirely declarative config, rendered via `[{DataFeed source='landslide-events' ...}]` in `Landslides.md`.
+No redundancy here — unlike volcano data, landslides have exactly one pipeline: a generic `geojson`-adapter `DataFeed` config entry pointed straight at NASA's own COOLR ArcGIS FeatureServer. There's no bespoke manager/plugin (`addons/geohazardwatch/managers/` and `plugins/` have nothing landslide-specific) — it's entirely declarative config, rendered via `[{DataFeed source='landslide-events' ...}]` in `landslides.md`.
 
 ## Field mapping (production config)
 

--- a/docs/tsunami-sources.md
+++ b/docs/tsunami-sources.md
@@ -4,7 +4,7 @@
 
 | Our pipeline | Upstream (real source) | Kind | Poll interval | Rendered on |
 |---|---|---|---|---|
-| `tsunami-alerts` (ngdpbase `feeds` addon) | `api.weather.gov/alerts/active` (NOAA / National Weather Service) | **Primary**, single source, no bespoke code | 10 min | `Tsunamis.md` (`/view/tsunamis`) |
+| `tsunami-alerts` (ngdpbase `feeds` addon) | `api.weather.gov/alerts/active` (NOAA / National Weather Service) | **Primary**, single source, no bespoke code | 10 min | `tsunamis.md` (`/view/tsunamis`) |
 | `tsunami` flag on `EarthquakeDataManager` records | `earthquake.usgs.gov/earthquakes/feed/v1.0/summary` (USGS) | **Secondary/related signal** — USGS's own per-quake tsunami-potential boolean, not an alert feed | shares the earthquake import cadence | exposed via `EarthquakeDataManager`'s `tsunamiOnly` filter; not a dedicated tsunami page |
 
 Like landslides, the primary tsunami feed is a single declarative `DataFeed` config entry (`geojson` adapter) with no bespoke manager/plugin — filtered directly to `event=Tsunami Warning,Tsunami Advisory,Tsunami Watch` against NWS's own active-alerts API. This is the *actual issuing authority* for US tsunami alerts, not a re-publisher — there's no equivalent to volcano data's re-publisher problem here.

--- a/docs/wildfire-sources.md
+++ b/docs/wildfire-sources.md
@@ -27,17 +27,17 @@ Adapter: `csv` (unlike the other three hazard categories, which all use `geojson
 
 ## Wildfire alert design (decided, geohazardwatch#161)
 
-Design decision for what counts as an "alert-worthy" wildfire unit on the consolidated [Alerts page](../addons/geohazardwatch/pages/Alerts.md) (geohazardwatch#160). No new code in this decision itself — implementation belongs to the sub-issues below.
+Design decision for what counts as an "alert-worthy" wildfire unit on the consolidated [Alerts page](../addons/geohazardwatch/pages/alerts.md) (geohazardwatch#160). No new code in this decision itself — implementation belongs to the sub-issues below.
 
 | Question | Decision | Rationale |
 |---|---|---|
-| Threshold | High-confidence detections only (`confidence` != low/nominal); no FRP floor | Matches the filter already live on `Wildfires.md` (`exclude='confidence~^[ln]$'`) — reuses an existing, already-configured pattern instead of introducing a second, differently-tuned threshold |
+| Threshold | High-confidence detections only (`confidence` != low/nominal); no FRP floor | Matches the filter already live on `wildfires.md` (`exclude='confidence~^[ln]$'`) — reuses an existing, already-configured pattern instead of introducing a second, differently-tuned threshold |
 | Clustering | Threshold-only for now — list raw high-confidence detections, not grouped events | `DataFeedPlugin` (ngdpbase `feeds` addon) supports `source`/`exclude`/`columns`/`sort`/`max`/`sizeBy`/`badge`/`link` but has no group-by/clustering parameter (verified against `DataFeedPlugin.ts`); real clustering (spatial grouping + event lifecycle) is separate, not-yet-started work and would need its own implementation issue |
-| Scope | Global | Matches `Wildfires.md`'s existing global map — scoping the Alerts-page list to US-only while the map stays global would be inconsistent between the two pages |
+| Scope | Global | Matches `wildfires.md`'s existing global map — scoping the Alerts-page list to US-only while the map stays global would be inconsistent between the two pages |
 | Naming/display | Reverse geocode each detection to its nearest named place | `firms-viirs` only provides `latitude`/`longitude`/`frp`/`confidence`/`acq_date`/`acq_time` — no place name. Reverse geocoding is a **new external data source** (provider TBD, likely requires an API key) — out of scope for #161 itself; needs its own issue and, per this repo's agent priority matrix, human review before implementation |
 
 ## Known issues / follow-ups
 
 - If a real wildfire feature (not just volcano-adjacent thermal detection) is ever wanted, `firms-viirs` is already the right upstream source — it would need its own page/plugin rather than reusing `FirmsHotspotsPlugin`, which is purpose-built for the volcano proximity join.
-- Like `VaacAdvisoriesPlugin`, this pipeline works and has real data but isn't surfaced anywhere a visitor would see it — worth deciding whether to wire it into `VolcanoActivity.md` or a dedicated page, or leave it demo-only.
+- Like `VaacAdvisoriesPlugin`, this pipeline works and has real data but isn't surfaced anywhere a visitor would see it — worth deciding whether to wire it into `volcano-activity.md` or a dedicated page, or leave it demo-only.
 - The FIRMS API key lives only in production's `app-custom-config.json` (not in this repo) — do not add the literal key value to any committed file.


### PR DESCRIPTION
Closes step 1 and step 2 of #177's suggested order (both independent of any ngdpbase change; steps 3-4 stay blocked on ngdpbase#952 and ngdpbase#971 respectively).

## 1. `system-category` — every page now categorized

| Page | Before | After |
|---|---|---|
| earthquakes | *(none)* | `general` |
| volcanoes | *(none)* | `general` |
| japan-volcanoes | *(none)* | `general` |
| us-volcano-alerts-usgs-hans | *(none)* | `general` |
| tsunamis | `addon` | `general` |
| landslides | `addon` | `general` |
| volcano-activity | `addon` | `general` |
| volcanoes-and-earthquakes | `addon` | `general` |
| geology-demo | *(none)* | `general` |
| geohazardwatch-plugins | *(none)* | `general` |
| geohazardwatch-about | *(none)* | `documentation` |
| **attribution** | `addon` | **`documentation`** ← decision made below |
| footer-content | `addon` | `system` |
| left-menu-content | `addon` | `system` |
| alerts *(new since audit)* | `addon` | `general` |
| wildfires *(new since audit)* | `addon` | `general` |

**Deciding `attribution`**: #177 flagged this as genuinely undecided upstream (§9 narrowed it to `documentation` or `system` and stopped, noting `storageLocation` is `required` either way so the practical difference is nil). Went with `documentation` — it groups with the About page (informational/credits content) rather than site-chrome pages like the footer/left-menu, which is the closer semantic fit.

**`alerts`/`wildfires`**: added to this addon after the original 14-page audit, still carrying `system-category: addon`. Recategorized to `general` for the same reason as the rest of the domain-content pages — leaving them as the only two still on the catch-all label would just reintroduce the problem this issue fixes.

## 2. Filenames — `basename === slug` for all 16 pages

12 renames via `git mv` (history preserved): 4 case-only, 6 real filename/slug drift (`geohazardwatch-*.md` → their actual slugs), 2 new-page case fixes (Alerts/Wildfires).

Updated every in-repo doc reference to the old filenames (`AGENTS.md`, `addons/geohazardwatch/README.md`'s pages tree, `docs/*-sources.md`) so nothing here still points at a stale name. Confirmed via repo-wide grep — no remaining hits outside `CHANGELOG.md`.

## Not in scope here

- `domainDefaults` in `package.json` — blocked on ngdpbase#952 (config keys not final)
- `access` opt-outs — blocked on ngdpbase#971 (platform doesn't stamp `access` yet)

## Verification

- `npm run lint:md` — clean
- `basename === slug` confirmed for all 16 pages via script
- No stale old-filename references remain in-repo (grepped, excluding CHANGELOG.md)

## Before merging

Merging to `main` touches `addons/**`, which triggers `auto-tag.yml` → a new release → image rebuild → eventual redeploy. Per #177's closing note, worth confirming reseed behavior afterward on the live instance: `pageSourceHash` covers body only, so these metadata-only frontmatter changes should be reseed-neutral (not mark pages `locally-modified`) — but that's worth confirming rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)