### PR TITLE
fix(#178): auto-tag.yml no longer tags before the branch push is confirmed

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -46,29 +46,41 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump patch, commit, tag, push
+      - name: Bump patch, commit, push, then tag
         run: |
-          npm run version:bump -- patch
-          VERSION=$(node -p "require('./package.json').version")
-          git add -A
-          git commit -m "chore: release v${VERSION}"
-          git tag -a "v${VERSION}" -m "geohazardwatch v${VERSION}"
-
-          # Race-safe push: if another commit landed on main between checkout
-          # and push, rebase the release commit on top of origin/main and retry.
-          # The annotated tag points at a specific SHA, so it must be dropped
-          # before rebase and re-created after, otherwise --follow-tags would
-          # push a tag pointing at an orphan commit.
+          # #178: the tag must never be created before the branch push it
+          # names is confirmed on origin/main. A prior version bundled both
+          # via `git push --follow-tags`, which can partially succeed — the
+          # new tag ref lands even when the bundled branch-ref update is
+          # rejected (no fast-forward constraint on a brand-new ref). Two
+          # auto-tag runs racing within seconds of each other (two Renovate
+          # PRs merging back-to-back) hit exactly this: the loser's tag still
+          # got created, permanently naming a stale commit, while the winner's
+          # branch push landed under a tag name that was already taken.
+          #
+          # Fixed by never tagging speculatively: push the branch alone first;
+          # only on confirmed success do we create+push the tag, so it always
+          # names the commit actually on origin/main. On rejection, discard
+          # the attempt entirely and restart from a fresh origin/main rather
+          # than rebasing — recomputing the version fresh each attempt also
+          # avoids reusing a stale-computed version number against a newer
+          # base.
           for attempt in 1 2; do
-            if git push --follow-tags origin main; then
+            npm run version:bump -- patch
+            VERSION=$(node -p "require('./package.json').version")
+            git add -A
+            git commit -m "chore: release v${VERSION}"
+
+            if git push origin main; then
+              git tag -a "v${VERSION}" -m "geohazardwatch v${VERSION}"
+              git push origin "v${VERSION}"
               exit 0
             fi
-            echo "Push rejected; rebasing on origin/main and retrying (attempt ${attempt})"
+
+            echo "Branch push rejected; discarding and retrying against origin/main (attempt ${attempt})"
             git fetch origin main
-            git tag -d "v${VERSION}"
-            git rebase origin/main
-            git tag -a "v${VERSION}" -m "geohazardwatch v${VERSION}"
+            git reset --hard origin/main
           done
 
-          echo "Push still rejected after rebase + retry; failing." >&2
+          echo "Push still rejected after retry; failing." >&2
           exit 1


### PR DESCRIPTION
Closes #178.

## The bug

\`git push --follow-tags\` bundles a branch-ref update and a new tag-ref creation in one call, but they're evaluated independently by the server — the tag ref has no fast-forward constraint (it's brand new), so it can land even when the bundled branch-ref update is rejected as non-fast-forward.

Reproduced live on 2026-07-26: two Renovate PRs merged 3 seconds apart, each triggering \`auto-tag.yml\` (both touch its trigger paths). Both runs independently computed the same next patch version, \`v1.2.116\`:

- Run A (checked out the older commit, per \`actions/checkout\`'s default pin to \`github.sha\`) pushed second in wall-clock terms but *first* attempted \`git push --follow-tags\` — its branch update was rejected (main had already advanced), but its \`v1.2.116\` tag ref still got created, since tag creation isn't fast-forward-gated.
- Run B (checked out the newer commit) then pushed — its branch update succeeded and correctly landed on \`main\` — but it never got to claim \`v1.2.116\` for itself, since that tag name was already taken by Run A's stale commit.

Net effect: \`publish-image.yml\` built and shipped an image from \`v1.2.116\`, which pointed at a commit still on the pre-bump Dockerfile (ngdpbase 3.68.3, not 3.69.0). \`main\`'s actual correct commit went unreleased under any tag until manually re-triggered.

## The fix

Restructure the release step so a tag is never created speculatively:

1. Bump version, commit, and push **the branch only**.
2. Only on confirmed success, create and push the tag — so it always names whatever commit is actually on \`origin/main\`, never a guess.
3. On rejection, discard the local commit entirely and restart from a freshly fetched \`origin/main\` (recomputing the version bump from scratch), rather than rebasing a stale-computed version number onto a newer base — simpler than the previous drop-tag/rebase/re-tag dance, and avoids a related latent issue where a rebase-retry reused a version number computed before the rebase instead of re-deriving it against the new base.

## Related

#148 (a separate, GitHub-side webhook delivery *delay* for the tag-push event, not something this repo can fix) shares the same underlying fragility — bundling branch and tag pushes together via \`--follow-tags\` and relying on tag-push-triggered automation downstream. This fix doesn't address #148 directly, but separating the pushes was #148's own suggested follow-up, and doing so here happens to also close #178.

## Verification

- YAML validated (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- \`npm run lint\` — clean
- Reasoned through the race scenario against the new script: since a tag is only created after a confirmed branch-push success naming a fresh version computed against that exact confirmed state, two concurrent runs can no longer produce a tag pointing at a stale commit — whichever run's branch push actually lands is the only one that tags, and it tags correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)