### PR TITLE
fix: two-stage Docker build — npm removed from ngdpbase base image (#956)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,40 @@
 # NOTE: the running instance's addons-path config (app-custom-config.json,
 # set via the runtime ConfigMap, not here) must include
 # "node_modules:@jwilleke/*-addon" for this image to actually load the addon.
+#
+# Two stages, not one: ngdpbase#956 removed npm/npx from the ngdpbase
+# runtime image entirely (as of NGDPBASE_VERSION >= 3.70.3) — reasonable
+# for ngdpbase's own runtime, which never shells out to npm, but this
+# repo's "packaged/npm model" needs npm to install the addon package at
+# build time. Installing it in a plain Node image instead, then copying
+# just its node_modules into the ngdpbase-based runtime stage, keeps this
+# working with no npm required in the final image.
 
 ARG NGDPBASE_VERSION=3.70.3
+ARG NODE_VERSION=24
+
+# =============================================================================
+# Stage 1: addon-installer — plain Node image, still has npm
+# =============================================================================
+FROM node:${NODE_VERSION}-alpine AS addon-installer
+
+WORKDIR /app
+
+ARG GEOHAZARDWATCH_ADDON_VERSION
+COPY .npmrc ./
+
+# Installs the addon as an ordinary npm dependency into /app/node_modules.
+# The GitHub token is mounted only for this RUN step (BuildKit secret) and
+# is never written to an image layer; .npmrc is removed in the same layer
+# once the install completes.
+RUN --mount=type=secret,id=github_token \
+    NODE_AUTH_TOKEN="$(cat /run/secrets/github_token)" \
+    npm install "@jwilleke/geohazardwatch-addon@${GEOHAZARDWATCH_ADDON_VERSION}" --omit=dev && \
+    rm -f .npmrc
+
+# =============================================================================
+# Stage 2: runtime — ngdpbase base image, no npm needed or present
+# =============================================================================
 FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}
 
 LABEL org.opencontainers.image.title="geohazardwatch"
@@ -26,15 +58,10 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
 
-ARG GEOHAZARDWATCH_ADDON_VERSION
-COPY .npmrc ./
-
-# Installs the addon as an ordinary npm dependency into /app/node_modules,
-# where ngdpbase's `node_modules:@jwilleke/*-addon` addons-path glob finds
-# it. The GitHub token is mounted only for this RUN step (BuildKit secret)
-# and is never written to an image layer; .npmrc is removed in the same
-# layer once the install completes.
-RUN --mount=type=secret,id=github_token \
-    NODE_AUTH_TOKEN="$(cat /run/secrets/github_token)" \
-    npm install "@jwilleke/geohazardwatch-addon@${GEOHAZARDWATCH_ADDON_VERSION}" --omit=dev && \
-    rm -f .npmrc
+# Merges the addon-installer's node_modules (the addon + its own deps, e.g.
+# express) into the runtime image's existing node_modules from ngdpbase's
+# own build — the trailing `/.` copies contents into the destination
+# rather than replacing it, so ngdpbase's own dependencies are preserved.
+# ngdpbase's `node_modules:@jwilleke/*-addon` addons-path glob finds the
+# addon here exactly as before.
+COPY --from=addon-installer /app/node_modules/. ./node_modules/


### PR DESCRIPTION
## The break

Every release since `v1.2.124` has failed to build. Root cause: [ngdpbase#956](https://github.com/jwilleke/ngdpbase/issues/956) (landed in ngdpbase v3.70.3) removed `npm`/`npx` from the ngdpbase runtime image entirely, to eliminate CVE noise from npm's own bundled `tar`/`brace-expansion`. That analysis was scoped entirely to ngdpbase's own runtime needs (grepped its own docker-compose/k8s/deploy scripts) — it never considered that this repo uses `ghcr.io/jwilleke/ngdpbase` **as a base image** and needs `npm` at build time for its documented "packaged/npm model" (#152).

```
#13 [stage-0 4/4] RUN --mount=type=secret,id=github_token ... npm install "@jwilleke/geohazardwatch-addon@1.2.124" --omit=dev && rm -f .npmrc
#13 0.050 /bin/sh: npm: not found
#13 ERROR: process ... did not complete successfully: exit code: 127
```

## The fix

Two-stage build instead of one:

1. **`addon-installer`** — plain `node:24-alpine` (still has npm), installs `@jwilleke/geohazardwatch-addon` exactly as before.
2. **runtime** — the ngdpbase base image as before, but now `COPY --from=addon-installer /app/node_modules/. ./node_modules/` merges the addon's `node_modules` into the runtime image's existing one (from ngdpbase's own build) instead of running npm inside it. The trailing `/.` on the source and `/` on the destination make this a merge, not a replace — ngdpbase's own ~382 packages survive untouched.

No npm needed in the final image at all — stays compatible with ngdpbase#956's actual goal (npm-free runtime) while fixing what it broke downstream.

## Verified with a real local build

- `docker buildx build` succeeds end to end
- Final image: `ls node_modules | wc -l` → 382 (ngdpbase's own deps intact) + `node_modules/@jwilleke/geohazardwatch-addon` present
- `which npm` in the final image → exit 1 (correctly absent, matches #956's intent)
- Full smoke test matching this repo's own CI steps: container reaches Docker `healthy` in ~35s, `GET /` → `302` (same acceptance criteria `publish-image.yml` uses)

## Related

Also worth ngdpbase filing this as a documented breaking-change gap in #956 for anyone else building on that base image — will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)