### PR TITLE
chore: build addon-installer FROM ngdpbase's official -devtools tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,18 @@
 # runtime image entirely (as of NGDPBASE_VERSION >= 3.70.3) — reasonable
 # for ngdpbase's own runtime, which never shells out to npm, but this
 # repo's "packaged/npm model" needs npm to install the addon package at
-# build time. Installing it in a plain Node image instead, then copying
-# just its node_modules into the ngdpbase-based runtime stage, keeps this
-# working with no npm required in the final image.
+# build time. ngdpbase#1001/v4.0.0 added an official `-devtools` tag
+# (npm restored, not for deployment) precisely for this — the installer
+# stage below builds FROM that instead of a generic Node image, so it
+# stays in lockstep with ngdpbase's own Node version automatically. Only
+# its node_modules gets copied into the plain (npm-free) runtime stage.
 
-ARG NGDPBASE_VERSION=3.71.0
-ARG NODE_VERSION=24
+ARG NGDPBASE_VERSION=4.0.0
 
 # =============================================================================
-# Stage 1: addon-installer — plain Node image, still has npm
+# Stage 1: addon-installer — ngdpbase's own devtools variant (has npm)
 # =============================================================================
-FROM node:${NODE_VERSION}-alpine AS addon-installer
+FROM ghcr.io/jwilleke/ngdpbase:${NGDPBASE_VERSION}-devtools AS addon-installer
 
 WORKDIR /app
 


### PR DESCRIPTION
Follow-up to the two-stage build fix in #188 — swaps the generic \`node:24-alpine\` installer stage for ngdpbase's new official \`-devtools\` tag now that [ngdpbase#1001](https://github.com/jwilleke/ngdpbase/issues/1001)/v4.0.0 has shipped it.

## What changes

- Installer stage: \`FROM ghcr.io/jwilleke/ngdpbase:\${NGDPBASE_VERSION}-devtools\` instead of \`node:\${NODE_VERSION}-alpine\` — stays in lockstep with ngdpbase's own Node version automatically, no separate ARG to drift.
- Bumped \`NGDPBASE_VERSION\` to \`4.0.0\` (\`-devtools\` tags only exist from v4.0.0 onward).
- Functional outcome unchanged: same merge-into-runtime-stage pattern from #188.

## Why this needed real verification, not just reasoning

The \`-devtools\` stage already has ngdpbase's own \`package.json\`/\`node_modules\` populated at \`/app\` (it's \`FROM runtime\` + npm restored) — unlike the previous \`node:24-alpine\` stage, which started from an empty directory. So \`npm install\` here runs against ngdpbase's own manifest, not a clean scratch install. Built it for real rather than assuming that's fine:

- \`npm install\` added exactly **1** new package (the addon itself) — \`express\` and other shared deps were already satisfied by ngdpbase's own \`node_modules\`, more efficient than the previous isolated install
- Final image: \`node_modules\` count unchanged (382, same as before), addon present under \`node_modules/@jwilleke/\`
- Final stage's \`package.json\` unaffected (still reads \`"name": "ngdpbase"\`) — confirms the installer stage's \`package.json\` mutation never reaches the runtime stage, only its \`node_modules\` does
- \`npm\` correctly absent from the final image
- Full smoke test: container reaches \`healthy\` in ~35s, \`GET /\` → \`302\` — identical to #188's result

🤖 Generated with [Claude Code](https://claude.com/claude-code)