### PR TITLE
chore(deps): bump ngdpbase base image 4.0.0 -> 4.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 # stays in lockstep with ngdpbase's own Node version automatically. Only
 # its node_modules gets copied into the plain (npm-free) runtime stage.
 
-ARG NGDPBASE_VERSION=4.0.0
+ARG NGDPBASE_VERSION=4.0.1
 
 # =============================================================================
 # Stage 1: addon-installer — ngdpbase's own devtools variant (has npm)


### PR DESCRIPTION
Pulls in the fix for [ngdpbase#1003](https://github.com/jwilleke/ngdpbase/issues/1003) — directly resolves [geohazardwatch#191](https://github.com/jwilleke/geohazardwatch/issues/191) (12 pages wrongly locked to admin-only edit) and unblocks [#177](https://github.com/jwilleke/geohazardwatch/issues/177) step 4.

What shipped in 4.0.1:
- `system-category` now propagates source-first to already-seeded pages, instead of only applying at initial seed
- Access stamps produced from a stale category are cleared on the next boot, under a narrow condition set (category drifted + corrected category maps to no stamp + source declares no explicit access + live access is byte-identical to what the stale category would have produced)

Confirmed both `ghcr.io/jwilleke/ngdpbase:4.0.1` and `:4.0.1-devtools` exist and pull cleanly.

Will verify live after this deploys — all 16 pages should show their §9 category and the 12 `general` ones should have no `access` key at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)