### PR TITLE
chore(deps): bump ngdpbase base image 4.8.1 -> 4.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 # stays in lockstep with ngdpbase's own Node version automatically. Only
 # its node_modules gets copied into the plain (npm-free) runtime stage.
 
-ARG NGDPBASE_VERSION=4.8.1
+ARG NGDPBASE_VERSION=4.8.2
 
 # =============================================================================
 # Stage 1: addon-installer — ngdpbase's own devtools variant (has npm)


### PR DESCRIPTION
Unblocks the build (#223). \`4.8.1-devtools\` was never published to GHCR, so the build/publish workflow for the addon-installer stage failed:

\`\`\`
ERROR: failed to build: failed to solve: ghcr.io/jwilleke/ngdpbase:4.8.1-devtools: not found
\`\`\`

\`4.8.2-devtools\` is now published (see jwilleke/ngdpbase#1035). Bumping the pin to match.

Closes #223 once this build succeeds.