### PR TITLE
chore: gitignore the generated VAAC advisory data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ addons/geohazardwatch/data/eruptions.json
 addons/geohazardwatch/data/global-activity.json
 addons/geohazardwatch/data/earthquakes.json
 addons/geohazardwatch/data/activity.json
+addons/geohazardwatch/data/vaac.json
 geohazardwatch.code-workspace
 
 # Private notes (never commit)


### PR DESCRIPTION
`addons/geohazardwatch/data/vaac.json` is generated by `npm run import:vaac` and refreshed on a background timer every 30 minutes. The other five generated files in that directory are already ignored:

```text
# Generated data files (run npm run import to regenerate)
addons/geohazardwatch/data/volcanoes.json
addons/geohazardwatch/data/eruptions.json
addons/geohazardwatch/data/global-activity.json
addons/geohazardwatch/data/earthquakes.json
addons/geohazardwatch/data/activity.json
+ addons/geohazardwatch/data/vaac.json
```

This one was missed when the VAAC import landed.

Left tracked, it dirties the working tree twice an hour, which blocks anything requiring a clean tree — the agent-kit sync refuses to run against one, which is how it surfaced.